### PR TITLE
Cleanup warnings

### DIFF
--- a/libinstpatch/CMakeLists.txt
+++ b/libinstpatch/CMakeLists.txt
@@ -241,6 +241,8 @@ add_definitions ( -DLOCALEDIR="${DATA_INSTALL_DIR}/locale" )
 set (DEFINITION_FILE "")
 # Options for WINDOWS only
 if( WIN32 )
+    # disable deprecation warnings 
+    add_definitions ( -D_CRT_SECURE_NO_WARNINGS )
     if (BUILD_SHARED_LIBS)
         # adding a module definition file for shared libs will export symbols and produce import library
         set (DEFINITION_FILE libinstpatch.def)

--- a/libinstpatch/IpatchDLS2.c
+++ b/libinstpatch/IpatchDLS2.c
@@ -433,7 +433,7 @@ ipatch_dls2_base_find_unused_locale (IpatchBase *base, int *bank,
   GSList *locale_list = NULL;
   IpatchDLS2Inst *inst;
   GSList *p;
-  int b, n;			/* Stores current bank and preset number */
+  guint32 b, n;			/* Stores current bank and preset number */
   guint32 lbank, lprogram;
 
   /* fill array with bank and preset numbers */
@@ -459,8 +459,8 @@ ipatch_dls2_base_find_unused_locale (IpatchBase *base, int *bank,
 
   locale_list = g_slist_sort (locale_list, (GCompareFunc)locale_gcompare_func);
 
-  b = *bank;
-  n = *program;
+  b = (guint32)*bank;
+  n = (guint32)*program;
 
   /* loop through sorted list of bank:programs */
   p = locale_list;
@@ -470,7 +470,7 @@ ipatch_dls2_base_find_unused_locale (IpatchBase *base, int *bank,
       lbank = lprogram >> 16;
       lprogram &= 0xFFFF;
 
-      if (lbank > (guint32)b || (lbank == b && lprogram > (guint32)n)) break;
+      if (lbank > b || (lbank == b && lprogram > n)) break;
       if (lbank >= (guint32)b)
 	{
 	  if (++n > 127)

--- a/libinstpatch/IpatchDLS2.c
+++ b/libinstpatch/IpatchDLS2.c
@@ -471,7 +471,7 @@ ipatch_dls2_base_find_unused_locale (IpatchBase *base, int *bank,
       lprogram &= 0xFFFF;
 
       if (lbank > b || (lbank == b && lprogram > n)) break;
-      if (lbank >= (guint32)b)
+      if (lbank >= b)
 	{
 	  if (++n > 127)
 	    {

--- a/libinstpatch/IpatchDLS2.c
+++ b/libinstpatch/IpatchDLS2.c
@@ -470,8 +470,8 @@ ipatch_dls2_base_find_unused_locale (IpatchBase *base, int *bank,
       lbank = lprogram >> 16;
       lprogram &= 0xFFFF;
 
-      if (lbank > b || (lbank == b && lprogram > n)) break;
-      if (lbank >= b)
+      if (lbank > (guint32)b || (lbank == b && lprogram > (guint32)n)) break;
+      if (lbank >= (guint32)b)
 	{
 	  if (++n > 127)
 	    {

--- a/libinstpatch/IpatchDLSReader.c
+++ b/libinstpatch/IpatchDLSReader.c
@@ -368,7 +368,7 @@ ipatch_dls_reader_fixup (IpatchDLSReader *reader, GError **err)
 
   /* create pool table index -> sample hash */
   i = 0;
-  while (i < reader->pool_table_size)
+  while ((guint)i < reader->pool_table_size)
     {
       sample = g_hash_table_lookup (reader->wave_hash,
 				    GINT_TO_POINTER (reader->pool_table[i]));
@@ -1404,10 +1404,10 @@ ipatch_dls_load_region_header (IpatchRiff *riff,
 
   if (!ipatch_file_buf_load (riff->handle, chunk->size, err)) return (FALSE);
 
-  region->note_range_low = ipatch_file_buf_read_u16 (riff->handle);
-  region->note_range_high = ipatch_file_buf_read_u16 (riff->handle);
-  region->velocity_range_low = ipatch_file_buf_read_u16 (riff->handle);
-  region->velocity_range_high = ipatch_file_buf_read_u16 (riff->handle);
+  region->note_range_low = (guint8)ipatch_file_buf_read_u16 (riff->handle);
+  region->note_range_high = (guint8)ipatch_file_buf_read_u16 (riff->handle);
+  region->velocity_range_low = (guint8)ipatch_file_buf_read_u16 (riff->handle);
+  region->velocity_range_high = (guint8)ipatch_file_buf_read_u16 (riff->handle);
 
   /* ISOK? Undefined flags are discarded! */
   options = ipatch_file_buf_read_u16 (riff->handle);
@@ -1455,10 +1455,10 @@ ipatch_gig_load_region_header (IpatchRiff *riff,
 
   if (!ipatch_file_buf_load (riff->handle, chunk->size, err)) return (FALSE);
 
-  region->note_range_low = ipatch_file_buf_read_u16 (riff->handle);
-  region->note_range_high = ipatch_file_buf_read_u16 (riff->handle);
-  region->velocity_range_low = ipatch_file_buf_read_u16 (riff->handle);
-  region->velocity_range_high = ipatch_file_buf_read_u16 (riff->handle);
+  region->note_range_low = (guint8)ipatch_file_buf_read_u16 (riff->handle);
+  region->note_range_high = (guint8)ipatch_file_buf_read_u16 (riff->handle);
+  region->velocity_range_low = (guint8)ipatch_file_buf_read_u16 (riff->handle);
+  region->velocity_range_high = (guint8)ipatch_file_buf_read_u16 (riff->handle);
 
   /* ISOK? Undefined flags are discarded! */
   options = ipatch_file_buf_read_u16 (riff->handle);

--- a/libinstpatch/IpatchDLSReader.c
+++ b/libinstpatch/IpatchDLSReader.c
@@ -357,7 +357,7 @@ ipatch_dls_reader_fixup (IpatchDLSReader *reader, GError **err)
   IpatchGigRegion *gig_region;
   IpatchGigSubRegion *sub_region;
   IpatchIter inst_iter, region_iter;
-  int i;
+  guint i;
 
   g_return_val_if_fail (IPATCH_IS_DLS_READER (reader), FALSE);
   g_return_val_if_fail (!err || !*err, FALSE);
@@ -368,7 +368,7 @@ ipatch_dls_reader_fixup (IpatchDLSReader *reader, GError **err)
 
   /* create pool table index -> sample hash */
   i = 0;
-  while ((guint)i < reader->pool_table_size)
+  while (i < reader->pool_table_size)
     {
       sample = g_hash_table_lookup (reader->wave_hash,
 				    GINT_TO_POINTER (reader->pool_table[i]));

--- a/libinstpatch/IpatchFile.c
+++ b/libinstpatch/IpatchFile.c
@@ -1887,11 +1887,11 @@ ipatch_file_default_getfd_method (IpatchFileHandle *handle)
 int
 ipatch_file_default_get_size_method (IpatchFile *file, GError **err)
 {
-  struct stat info;
+  GStatBuf info;
 
   if (file->file_name)
   {
-    if (g_stat (file->file_name, (GStatBuf *)&info) != 0)
+    if (g_stat (file->file_name, &info) != 0)
     {
       g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
                    _("Error during call to stat(\"%s\"): %s"),

--- a/libinstpatch/IpatchFile.c
+++ b/libinstpatch/IpatchFile.c
@@ -1891,7 +1891,7 @@ ipatch_file_default_get_size_method (IpatchFile *file, GError **err)
 
   if (file->file_name)
   {
-    if (g_stat (file->file_name, &info) != 0)
+    if (g_stat (file->file_name, (GStatBuf *)&info) != 0)
     {
       g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
                    _("Error during call to stat(\"%s\"): %s"),

--- a/libinstpatch/IpatchFileBuf.c
+++ b/libinstpatch/IpatchFileBuf.c
@@ -526,7 +526,7 @@ ipatch_file_buf_seek (IpatchFileHandle *handle, int offset, GSeekType type)
   }
   else if (type == G_SEEK_SET)
   {
-    g_return_if_fail (offset >= 0 && offset < handle->buf->len);
+    g_return_if_fail (offset >= 0 && (guint)offset < handle->buf->len);
     handle->position += offset - handle->buf_position;
     handle->buf_position = offset;
   }

--- a/libinstpatch/IpatchGigRegion.c
+++ b/libinstpatch/IpatchGigRegion.c
@@ -691,7 +691,7 @@ ipatch_gig_region_remove_dimension (IpatchGigRegion *region, int dim_index,
     }
 
   max_split_index = 1 << region->dimensions[dim_index]->split_count;
-  if (log_if_fail (split_index > 0 && split_index < max_split_index))
+  if (log_if_fail (split_index > 0 && (guint)split_index < max_split_index))
     {
       IPATCH_ITEM_WUNLOCK (region);
       return;

--- a/libinstpatch/IpatchItem.c
+++ b/libinstpatch/IpatchItem.c
@@ -442,7 +442,7 @@ ipatch_item_set_parent (IpatchItem *item, IpatchItem *parent)
   gboolean is_container;
   SetParentBag bag;
   guint depth;
-  int i;
+  guint i;
 
   g_return_if_fail (IPATCH_IS_ITEM (item));
   g_return_if_fail (IPATCH_IS_ITEM (parent));
@@ -478,7 +478,7 @@ ipatch_item_set_parent (IpatchItem *item, IpatchItem *parent)
       /* lock it the number of times old mutex was locked, we don't use
 	 g_static_rec_mutex_lock_full because it could set depth rather than
 	 add to it */
-      for (i = 0; (guint)i < depth; i++)
+      for (i = 0; i < depth; i++)
 	g_static_rec_mutex_lock (item->mutex);
     }
 

--- a/libinstpatch/IpatchItem.c
+++ b/libinstpatch/IpatchItem.c
@@ -478,7 +478,7 @@ ipatch_item_set_parent (IpatchItem *item, IpatchItem *parent)
       /* lock it the number of times old mutex was locked, we don't use
 	 g_static_rec_mutex_lock_full because it could set depth rather than
 	 add to it */
-      for (i = 0; i < depth; i++)
+      for (i = 0; (guint)i < depth; i++)
 	g_static_rec_mutex_lock (item->mutex);
     }
 

--- a/libinstpatch/IpatchIter.c
+++ b/libinstpatch/IpatchIter.c
@@ -626,7 +626,7 @@ ipatch_iter_array_next (IpatchIter *iter)
   pos = IPATCH_ITER_ARRAY_GET_POS (iter);
   size = IPATCH_ITER_ARRAY_GET_SIZE (iter);
 
-  if (pos >= 0 && (pos + 1) < size) pos++;
+  if (pos >= 0 && (guint)(pos + 1) < size) pos++;
   else pos = -1;
 
   IPATCH_ITER_ARRAY_SET_POS (iter, pos); /* update position */
@@ -716,7 +716,7 @@ ipatch_iter_array_index (IpatchIter *iter, int index)
   g_return_val_if_fail (array != NULL, NULL);
 
   size = IPATCH_ITER_ARRAY_GET_SIZE (iter);
-  if (index < 0 || index >= size) index = -1;
+  if (index < 0 || (guint)index >= size) index = -1;
 
   IPATCH_ITER_ARRAY_SET_POS (iter, index);
 

--- a/libinstpatch/IpatchIter.c
+++ b/libinstpatch/IpatchIter.c
@@ -615,18 +615,17 @@ gpointer
 ipatch_iter_array_next (IpatchIter *iter)
 {
   gpointer *array;
-  int pos;
-  guint size;
+  guint pos,size;
 
   g_return_val_if_fail (iter != NULL, NULL);
 
   array = IPATCH_ITER_ARRAY_GET_ARRAY (iter);
   g_return_val_if_fail (array != NULL, NULL);
 
-  pos = IPATCH_ITER_ARRAY_GET_POS (iter);
+  pos = (guint)IPATCH_ITER_ARRAY_GET_POS (iter);
   size = IPATCH_ITER_ARRAY_GET_SIZE (iter);
 
-  if (pos >= 0 && (guint)(pos + 1) < size) pos++;
+  if (pos >= 0 && (pos + 1) < size) pos++;
   else pos = -1;
 
   IPATCH_ITER_ARRAY_SET_POS (iter, pos); /* update position */
@@ -708,15 +707,15 @@ gpointer
 ipatch_iter_array_index (IpatchIter *iter, int index)
 {
   gpointer *array;
-  guint size;
+  int size;
 
   g_return_val_if_fail (iter != NULL, NULL);
 
   array = IPATCH_ITER_ARRAY_GET_ARRAY (iter);
   g_return_val_if_fail (array != NULL, NULL);
 
-  size = IPATCH_ITER_ARRAY_GET_SIZE (iter);
-  if (index < 0 || (guint)index >= size) index = -1;
+  size = (int)IPATCH_ITER_ARRAY_GET_SIZE (iter);
+  if (index < 0 || index >= size) index = -1;
 
   IPATCH_ITER_ARRAY_SET_POS (iter, index);
 

--- a/libinstpatch/IpatchRiff.c
+++ b/libinstpatch/IpatchRiff.c
@@ -219,7 +219,7 @@ ipatch_riff_get_chunk (IpatchRiff *riff, int level)
   ipatch_riff_update_positions (riff);
 
   if (level == -1) level = riff->chunks->len - 1;
-  g_return_val_if_fail (level >= -1 && level < riff->chunks->len, NULL);
+  g_return_val_if_fail (level >= -1 && (guint)level < riff->chunks->len, NULL);
 
   return (&g_array_index (riff->chunks, IpatchRiffChunk, level));
 }
@@ -480,7 +480,7 @@ ipatch_riff_read_chunk (IpatchRiff *riff, GError **err)
 
       /* current chunk is sub chunk, or pos past end? */
       if (chunk->type == IPATCH_RIFF_CHUNK_SUB
-	  || chunk->position >= chunk->size)
+	  || (guint32)chunk->position >= chunk->size)
 	{
 	  riff->status = IPATCH_RIFF_STATUS_CHUNK_END;
 	  return (NULL);
@@ -812,7 +812,7 @@ ipatch_riff_close_chunk (IpatchRiff *riff, int level, GError **err)
   g_return_val_if_fail (!err || !*err, FALSE);
 
   if (level == -1) level = riff->chunks->len - 1;
-  g_return_val_if_fail (level >= -1 && level < riff->chunks->len, FALSE);
+  g_return_val_if_fail (level >= -1 && (guint)level < riff->chunks->len, FALSE);
 
   /* Update the chunk positions */
   ipatch_riff_update_positions (riff);
@@ -986,7 +986,7 @@ ipatch_riff_message_detail (IpatchRiff *riff, int level,
 
   /* level will be -1 if already -1 and no chunks */
   if (level == -1) level = riff->chunks->len - 1;
-  g_return_val_if_fail (level >= -1 && level < riff->chunks->len, NULL);
+  g_return_val_if_fail (level >= -1 && (guint)level < riff->chunks->len, NULL);
 
   va_start (args, format);
   msg = g_strdup_vprintf (format, args);

--- a/libinstpatch/IpatchRiff.c
+++ b/libinstpatch/IpatchRiff.c
@@ -212,14 +212,16 @@ ipatch_riff_get_chunk_array (IpatchRiff *riff, int *count)
 IpatchRiffChunk *
 ipatch_riff_get_chunk (IpatchRiff *riff, int level)
 {
+  int chunks_len;
   g_return_val_if_fail (IPATCH_IS_RIFF (riff), NULL);
   g_return_val_if_fail (riff->chunks->len > 0, NULL);
-
+  
   /* Update the chunk positions */
   ipatch_riff_update_positions (riff);
+  chunks_len = (int)riff->chunks->len;
 
-  if (level == -1) level = riff->chunks->len - 1;
-  g_return_val_if_fail (level >= -1 && (guint)level < riff->chunks->len, NULL);
+  if (level == -1) level = chunks_len - 1;
+  g_return_val_if_fail (level >= -1 && level < chunks_len, NULL);
 
   return (&g_array_index (riff->chunks, IpatchRiffChunk, level));
 }
@@ -472,15 +474,17 @@ ipatch_riff_read_chunk (IpatchRiff *riff, GError **err)
 
   if (riff->chunks->len > 0)
     {
-      /* Update the chunk positions */
+      guint32 chunk_position;
+	  /* Update the chunk positions */
       ipatch_riff_update_positions (riff);
 
       chunk = &g_array_index (riff->chunks, IpatchRiffChunk,
 			      riff->chunks->len - 1);
-
-      /* current chunk is sub chunk, or pos past end? */
+	  chunk_position = (guint32)chunk->position;
+      
+	  /* current chunk is sub chunk, or pos past end? */
       if (chunk->type == IPATCH_RIFF_CHUNK_SUB
-	  || (guint32)chunk->position >= chunk->size)
+	  || chunk_position >= chunk->size)
 	{
 	  riff->status = IPATCH_RIFF_STATUS_CHUNK_END;
 	  return (NULL);
@@ -804,15 +808,16 @@ ipatch_riff_close_chunk (IpatchRiff *riff, int level, GError **err)
   gint32 seek;
   guint32 size;
   int retval = TRUE;
-  int i;
+  int i,chunks_len;
 
   g_return_val_if_fail (IPATCH_IS_RIFF (riff), FALSE);
   g_return_val_if_fail (riff->status != IPATCH_RIFF_STATUS_FAIL, FALSE);
   g_return_val_if_fail (riff->chunks->len > 0, FALSE);
   g_return_val_if_fail (!err || !*err, FALSE);
-
-  if (level == -1) level = riff->chunks->len - 1;
-  g_return_val_if_fail (level >= -1 && (guint)level < riff->chunks->len, FALSE);
+  
+  chunks_len = (int)riff->chunks->len;
+  if (level == -1) level = chunks_len - 1;
+  g_return_val_if_fail (level >= -1 && level < chunks_len, FALSE);
 
   /* Update the chunk positions */
   ipatch_riff_update_positions (riff);
@@ -978,6 +983,7 @@ ipatch_riff_message_detail (IpatchRiff *riff, int level,
   IpatchRiffChunk *chunk;
   char *msg, *debug, *traceback = NULL, *s, *s2;
   int i, riffchunkpos = 0;
+  int chunks_len;
 
   g_return_val_if_fail (IPATCH_IS_RIFF (riff), NULL);
 
@@ -985,8 +991,9 @@ ipatch_riff_message_detail (IpatchRiff *riff, int level,
   ipatch_riff_update_positions (riff);
 
   /* level will be -1 if already -1 and no chunks */
-  if (level == -1) level = riff->chunks->len - 1;
-  g_return_val_if_fail (level >= -1 && (guint)level < riff->chunks->len, NULL);
+  chunks_len = (int)riff->chunks->len;
+  if (level == -1) level = chunks_len - 1;
+  g_return_val_if_fail (level >= -1 && level < chunks_len, NULL);
 
   va_start (args, format);
   msg = g_strdup_vprintf (format, args);

--- a/libinstpatch/IpatchSF2.c
+++ b/libinstpatch/IpatchSF2.c
@@ -570,7 +570,7 @@ ipatch_sf2_base_find_unused_locale (IpatchBase *base, int *bank,
   GSList *locale_list = NULL;
   IpatchSF2Preset *pset;
   GSList *p;
-  int b, n;			/* Stores current bank and program number */
+  guint b, n;			/* Stores current bank and program number */
   guint lbank, lprogram;
 
   if (percussion) *bank = 128;
@@ -606,8 +606,8 @@ ipatch_sf2_base_find_unused_locale (IpatchBase *base, int *bank,
       lbank = lprogram >> 16;
       lprogram &= 0xFFFF;
 
-      if (lbank > (guint)b || (lbank == b && lprogram > (guint)n)) break;
-      if (lbank >= (guint)b)
+      if (lbank > b || (lbank == b && lprogram > n)) break;
+      if (lbank >= b)
 	{
 	  if (++n > 127)
 	    {
@@ -780,12 +780,12 @@ ipatch_sf2_real_set_info (IpatchSF2 *sf, IpatchSF2InfoType id,
 			  const char *val)
 {
   char *newval = NULL;
-  int maxlen;
+  guint maxlen;
 
   maxlen = ipatch_sf2_get_info_max_size (id);
 
   /* value exceeds max length? */
-  if (maxlen > 0 && val && (int)strlen (val) > maxlen - 1)
+  if (maxlen > 0 && val && strlen (val) > maxlen - 1)
     {
       g_warning ("IpatchSF2Info string with id '%.4s' truncated",
 		 (char *)&id);

--- a/libinstpatch/IpatchSF2.c
+++ b/libinstpatch/IpatchSF2.c
@@ -606,8 +606,8 @@ ipatch_sf2_base_find_unused_locale (IpatchBase *base, int *bank,
       lbank = lprogram >> 16;
       lprogram &= 0xFFFF;
 
-      if (lbank > b || (lbank == b && lprogram > n)) break;
-      if (lbank >= b)
+      if (lbank > (guint)b || (lbank == b && lprogram > (guint)n)) break;
+      if (lbank >= (guint)b)
 	{
 	  if (++n > 127)
 	    {
@@ -785,7 +785,7 @@ ipatch_sf2_real_set_info (IpatchSF2 *sf, IpatchSF2InfoType id,
   maxlen = ipatch_sf2_get_info_max_size (id);
 
   /* value exceeds max length? */
-  if (maxlen > 0 && val && strlen (val) > maxlen - 1)
+  if (maxlen > 0 && val && (int)strlen (val) > maxlen - 1)
     {
       g_warning ("IpatchSF2Info string with id '%.4s' truncated",
 		 (char *)&id);

--- a/libinstpatch/IpatchSF2Reader.c
+++ b/libinstpatch/IpatchSF2Reader.c
@@ -506,7 +506,7 @@ sfload_infos (IpatchSF2Reader *reader, GError **err)
 		{
 		  maxsize = ipatch_sf2_get_info_max_size (chunk->id);
 
-		  if (chunk->size > maxsize)
+		  if (chunk->size > (guint32)maxsize)
 		    {
 		      g_warning (_("Invalid size %d for INFO chunk \"%.4s\""),
 				 chunk->size, chunk->idstr);
@@ -657,7 +657,7 @@ sfload_pbags (IpatchSF2Reader *reader, GError **err)
   pgenndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[0]);
   pmodndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[1]);
 
-  for (i=0; i < reader->pbag_count; i++)
+  for (i=0; (guint)i < reader->pbag_count; i++)
     {
       genndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2]);
       modndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2+1]);
@@ -983,7 +983,7 @@ sfload_ibags (IpatchSF2Reader *reader, GError **err)
   pgenndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[0]);
   pmodndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[1]);
 
-  for (i=0; i < reader->ibag_count; i++)
+  for (i=0; (guint)i < reader->ibag_count; i++)
     {
       genndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2]);
       modndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2+1]);
@@ -1384,7 +1384,7 @@ sfload_shdrs (IpatchSF2Reader *reader, GError **err)
   if (openlink_count > 0)	/* any unresolved linked stereo samples? */
     {
       count = reader->sample_count;
-      for (i = 0; i < reader->sample_count; i++)
+      for (i = 0; (guint)i < reader->sample_count; i++)
 	{
 	  sample = reader->sample_table[i];
 	  if ((ipatch_item_get_flags (sample) & (1 << 31)) && !ipatch_sf2_sample_peek_linked (sample))

--- a/libinstpatch/IpatchSF2Reader.c
+++ b/libinstpatch/IpatchSF2Reader.c
@@ -499,14 +499,14 @@ sfload_infos (IpatchSF2Reader *reader, GError **err)
 	    }
 	  else if (ipatch_sf2_info_id_is_valid (chunk->id))	/* regular string based info chunk */
 	    {
-	      int maxsize, size;
+	      guint32 maxsize, size;
 	      char *s;
 
 	      if (chunk->size > 0)
 		{
 		  maxsize = ipatch_sf2_get_info_max_size (chunk->id);
 
-		  if (chunk->size > (guint32)maxsize)
+		  if (chunk->size > maxsize)
 		    {
 		      g_warning (_("Invalid size %d for INFO chunk \"%.4s\""),
 				 chunk->size, chunk->idstr);
@@ -636,7 +636,7 @@ sfload_pbags (IpatchSF2Reader *reader, GError **err)
   guint16 *bag_table;
   guint16 genndx, modndx;
   guint16 pgenndx, pmodndx;
-  int i;
+  guint i;
 
   if (!ipatch_riff_read_chunk_verify (riff, IPATCH_RIFF_CHUNK_SUB,
 				      IPATCH_SFONT_FOURCC_PBAG, err))
@@ -657,7 +657,7 @@ sfload_pbags (IpatchSF2Reader *reader, GError **err)
   pgenndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[0]);
   pmodndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[1]);
 
-  for (i=0; (guint)i < reader->pbag_count; i++)
+  for (i=0; i < reader->pbag_count; i++)
     {
       genndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2]);
       modndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2+1]);
@@ -962,7 +962,7 @@ sfload_ibags (IpatchSF2Reader *reader, GError **err)
   guint16 *bag_table;
   guint16 genndx, modndx;
   guint16 pgenndx, pmodndx;
-  int i;
+  guint i;
 
   if (!ipatch_riff_read_chunk_verify (riff, IPATCH_RIFF_CHUNK_SUB,
 				      IPATCH_SFONT_FOURCC_IBAG, err))
@@ -983,7 +983,7 @@ sfload_ibags (IpatchSF2Reader *reader, GError **err)
   pgenndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[0]);
   pmodndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[1]);
 
-  for (i=0; (guint)i < reader->ibag_count; i++)
+  for (i=0; i < reader->ibag_count; i++)
     {
       genndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2]);
       modndx = IPATCH_FILE_SWAP16 (riff->handle->file, &bag_table[(i+1)*2+1]);
@@ -1201,7 +1201,7 @@ sfload_shdrs (IpatchSF2Reader *reader, GError **err)
   guint samchunk_pos, samchunk_size, sam24chunk_pos;
   guint openlink_count = 0;
   char *filename;
-  int i, count;
+  guint32 i, count;
 
   if (!ipatch_riff_read_chunk_verify (riff, IPATCH_RIFF_CHUNK_SUB,
 				      IPATCH_SFONT_FOURCC_SHDR, err))
@@ -1384,7 +1384,7 @@ sfload_shdrs (IpatchSF2Reader *reader, GError **err)
   if (openlink_count > 0)	/* any unresolved linked stereo samples? */
     {
       count = reader->sample_count;
-      for (i = 0; (guint)i < reader->sample_count; i++)
+      for (i = 0; i < reader->sample_count; i++)
 	{
 	  sample = reader->sample_table[i];
 	  if ((ipatch_item_get_flags (sample) & (1 << 31)) && !ipatch_sf2_sample_peek_linked (sample))

--- a/libinstpatch/IpatchSF2VoiceCache.c
+++ b/libinstpatch/IpatchSF2VoiceCache.c
@@ -128,7 +128,7 @@ ipatch_sf2_voice_cache_finalize (GObject *gobject)
 
   g_free (cache->sel_info);
 
-  for (i = 0; i < cache->voices->len; i++)
+  for (i = 0; (guint)i < cache->voices->len; i++)
     {
       voice = &g_array_index (cache->voices, IpatchSF2Voice, i);
 
@@ -305,7 +305,7 @@ ipatch_sf2_voice_cache_set_voice_range (IpatchSF2VoiceCache *cache,
 
   g_return_if_fail (IPATCH_IS_SF2_VOICE_CACHE (cache));
   g_return_if_fail (voice != NULL);
-  g_return_if_fail (sel_index < cache->sel_count);
+  g_return_if_fail (sel_index < (guint)cache->sel_count);
   g_return_if_fail (low <= high);
 
   rangep = (int *)(cache->ranges->data);

--- a/libinstpatch/IpatchSF2VoiceCache.c
+++ b/libinstpatch/IpatchSF2VoiceCache.c
@@ -124,11 +124,11 @@ ipatch_sf2_voice_cache_finalize (GObject *gobject)
 {
   IpatchSF2VoiceCache *cache = IPATCH_SF2_VOICE_CACHE (gobject);
   IpatchSF2Voice *voice;
-  int i;
+  guint i;
 
   g_free (cache->sel_info);
 
-  for (i = 0; (guint)i < cache->voices->len; i++)
+  for (i = 0; i < cache->voices->len; i++)
     {
       voice = &g_array_index (cache->voices, IpatchSF2Voice, i);
 

--- a/libinstpatch/IpatchSF2VoiceCache_DLS.c
+++ b/libinstpatch/IpatchSF2VoiceCache_DLS.c
@@ -122,7 +122,7 @@ _dls2_inst_to_sf2_voice_cache_convert (IpatchConverter *converter, GError **err)
           voice->loop_start = sample_info->loop_start;
           voice->loop_end = sample_info->loop_end;
           voice->root_note = sample_info->root_note;
-          voice->fine_tune = sample_info->fine_tune;
+          voice->fine_tune = (guint8)sample_info->fine_tune;
   
           switch (sample_info->options & IPATCH_DLS2_SAMPLE_LOOP_MASK)
             {
@@ -203,7 +203,7 @@ _dls2_sample_to_sf2_voice_cache_convert (IpatchConverter *converter,
       voice->loop_start = sample->sample_info->loop_start;
       voice->loop_end = sample->sample_info->loop_end;
       voice->root_note = sample->sample_info->root_note;
-      voice->fine_tune = sample->sample_info->fine_tune;
+      voice->fine_tune = (guint8)sample->sample_info->fine_tune;
 
       switch (sample->sample_info->options & IPATCH_DLS2_SAMPLE_LOOP_MASK)
         {

--- a/libinstpatch/IpatchSF2VoiceCache_Gig.c
+++ b/libinstpatch/IpatchSF2VoiceCache_Gig.c
@@ -235,7 +235,7 @@ _gig_inst_to_sf2_voice_cache_convert (IpatchConverter *converter, GError **err)
 	      voice->loop_start = sample_info->loop_start;
 	      voice->loop_end = sample_info->loop_end;
 	      voice->root_note = sample_info->root_note;
-	      voice->fine_tune = sample_info->fine_tune;
+	      voice->fine_tune = (guint8)sample_info->fine_tune;
 
 	      switch (sample_info->options & IPATCH_DLS2_SAMPLE_LOOP_MASK)
 		{

--- a/libinstpatch/IpatchSF2VoiceCache_VBank.c
+++ b/libinstpatch/IpatchSF2VoiceCache_VBank.c
@@ -137,7 +137,7 @@ _vbank_inst_to_sf2_voice_cache_convert (IpatchConverter *converter,
     note_high = region->note_range.high;
 
     /* loop over voices in item's voice cache */
-    for (voicendx = 0; voicendx < item_vcache->voices->len; voicendx++)
+    for (voicendx = 0; (guint)voicendx < item_vcache->voices->len; voicendx++)
     {
       item_voice = IPATCH_SF2_VOICE_CACHE_GET_VOICE (item_vcache, voicendx);
 

--- a/libinstpatch/IpatchSF2VoiceCache_VBank.c
+++ b/libinstpatch/IpatchSF2VoiceCache_VBank.c
@@ -70,7 +70,7 @@ _vbank_inst_to_sf2_voice_cache_convert (IpatchConverter *converter,
   int *note_range;
   int note_low, note_high;
   GError *localerr = NULL;
-  int voicendx;
+  guint voicendx;
   int root_note;
 
   obj = IPATCH_CONVERTER_INPUT (converter);
@@ -137,7 +137,7 @@ _vbank_inst_to_sf2_voice_cache_convert (IpatchConverter *converter,
     note_high = region->note_range.high;
 
     /* loop over voices in item's voice cache */
-    for (voicendx = 0; (guint)voicendx < item_vcache->voices->len; voicendx++)
+    for (voicendx = 0; voicendx < item_vcache->voices->len; voicendx++)
     {
       item_voice = IPATCH_SF2_VOICE_CACHE_GET_VOICE (item_vcache, voicendx);
 

--- a/libinstpatch/IpatchSF2Writer.c
+++ b/libinstpatch/IpatchSF2Writer.c
@@ -878,7 +878,7 @@ sfont_write_samples24 (IpatchSF2Writer *writer, GError **err)
   guint8 zerobuf[46 * 2]; /* 46 zero values to write at end of each sample */
   guint samsize, size, start, ofs, total_size, totalofs = 0;
   guint index = 0;
-  int i;
+  guint i;
 
   memset (&zerobuf, 0, sizeof (zerobuf));
 
@@ -966,11 +966,11 @@ sfont_write_samples24 (IpatchSF2Writer *writer, GError **err)
             goto error_close_handle;
 
 	  /* copy the LS bytes of the 24 bit samples */
-	  for (i = 0; (guint)i < size; i++)
+	  for (i = 0; i < size; i++)
 	    ((guint8 *)lsbuf)[i] = ((guint8 *)buf)[i * 4];
 
 	  /* compact the 16 bit portion of the 24 bit samples */
-	  for (i = 0; (guint)i < size; i++)
+	  for (i = 0; i < size; i++)
 	    {
 	      ((guint8 *)buf)[i * 2] = ((guint8 *)buf)[i * 4 + 1];
 	      ((guint8 *)buf)[i * 2 + 1] = ((guint8 *)buf)[i * 4 + 2];	      

--- a/libinstpatch/IpatchSF2Writer.c
+++ b/libinstpatch/IpatchSF2Writer.c
@@ -966,11 +966,11 @@ sfont_write_samples24 (IpatchSF2Writer *writer, GError **err)
             goto error_close_handle;
 
 	  /* copy the LS bytes of the 24 bit samples */
-	  for (i = 0; i < size; i++)
+	  for (i = 0; (guint)i < size; i++)
 	    ((guint8 *)lsbuf)[i] = ((guint8 *)buf)[i * 4];
 
 	  /* compact the 16 bit portion of the 24 bit samples */
-	  for (i = 0; i < size; i++)
+	  for (i = 0; (guint)i < size; i++)
 	    {
 	      ((guint8 *)buf)[i * 2] = ((guint8 *)buf)[i * 4 + 1];
 	      ((guint8 *)buf)[i * 2 + 1] = ((guint8 *)buf)[i * 4 + 2];	      

--- a/libinstpatch/IpatchSLIWriter.c
+++ b/libinstpatch/IpatchSLIWriter.c
@@ -669,10 +669,10 @@ ipatch_sli_writer_write_zone_header (IpatchFileHandle *handle, IpatchSLIZone *zo
   ipatch_file_buf_write_u32 (handle, 0); /* unknown2 */
 
   ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_COARSE_TUNE, &amount);
-  ipatch_file_buf_write_s8 (handle, amount.sword); /* coarse_tune1 */
+  ipatch_file_buf_write_s8 (handle, (guint8)amount.sword); /* coarse_tune1 */
 
   ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_FINE_TUNE_OVERRIDE, &amount);
-  ipatch_file_buf_write_s8 (handle, amount.sword); /* fine_tune1 */
+  ipatch_file_buf_write_s8 (handle, (guint8)amount.sword); /* fine_tune1 */
 
   ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_SAMPLE_MODES, &amount);
   if (amount.uword & IPATCH_SF2_GEN_SAMPLE_MODE_LOOP)
@@ -681,17 +681,17 @@ ipatch_sli_writer_write_zone_header (IpatchFileHandle *handle, IpatchSLIZone *zo
 
   if (!ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_ROOT_NOTE_OVERRIDE, &amount))
     amount.sword = 0;
-  ipatch_file_buf_write_s8 (handle, amount.sword); /* root_note */
+  ipatch_file_buf_write_s8 (handle, (guint8)amount.sword); /* root_note */
 
   if (!ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_SCALE_TUNE, &amount))
     amount.uword = 0;
   ipatch_file_buf_write_u16 (handle, amount.uword); /* scale_tuning */
 
   ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_COARSE_TUNE, &amount);
-  ipatch_file_buf_write_s8 (handle, amount.sword); /* coarse_tune2 */
+  ipatch_file_buf_write_s8 (handle, (guint8)amount.sword); /* coarse_tune2 */
 
   ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_FINE_TUNE_OVERRIDE, &amount);
-  ipatch_file_buf_write_s8 (handle, amount.sword); /* fine_tune2 */
+  ipatch_file_buf_write_s8 (handle, (guint8)amount.sword); /* fine_tune2 */
 
   ipatch_sf2_gen_item_get_amount (item, IPATCH_SF2_GEN_MOD_LFO_TO_PITCH, &amount);
   ipatch_file_buf_write_s16 (handle, amount.sword); /* modLfoToPitch */

--- a/libinstpatch/IpatchSampleData.c
+++ b/libinstpatch/IpatchSampleData.c
@@ -1299,7 +1299,7 @@ ipatch_sample_cache_clean (guint64 max_unused_size, guint max_unused_age)
     /* Once size drops below max_unused_size and max_unused_age is 0 or this
      * sample was used more recent than max_unused_age - we're done */
     if (cur_unused_size <= max_unused_size
-        && (max_unused_age == 0 || time.tv_sec - last_open <= max_unused_age))
+        && (max_unused_age == 0 || time.tv_sec - last_open <= (glong)max_unused_age))
       break;
 
     ipatch_sample_data_remove (sampledata, (IpatchSampleStore *)store);

--- a/libinstpatch/IpatchSampleStoreSplit24.c
+++ b/libinstpatch/IpatchSampleStoreSplit24.c
@@ -200,7 +200,7 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
 
     if (lilendian)
     {
-      for (i = 0; i < thissize; i++)
+      for (i = 0; (guint)i < thissize; i++)
       {
         i8p[i * 4 + 1] = readbuf[i * 2];
         i8p[i * 4 + 2] = readbuf[i * 2 + 1];
@@ -209,7 +209,7 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
     }
     else
     {
-      for (i = 0; i < thissize; i++)
+      for (i = 0; (guint)i < thissize; i++)
       {
         i8p[i * 4 + 2] = readbuf[i * 2];
         i8p[i * 4 + 1] = readbuf[i * 2 + 1];
@@ -241,12 +241,12 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
 
     if (lilendian)
     {
-      for (i = 0; i < thissize; i++)
+      for (i = 0; (guint)i < thissize; i++)
         i8p[i * 4] = readbuf[i];
     }
     else
     {
-      for (i = 0; i < thissize; i++)
+      for (i = 0; (guint)i < thissize; i++)
         i8p[i * 4 + 3] = readbuf[i];
     }
 

--- a/libinstpatch/IpatchSampleStoreSplit24.c
+++ b/libinstpatch/IpatchSampleStoreSplit24.c
@@ -176,7 +176,7 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
   IpatchFileHandle *fhandle = (IpatchFileHandle *)(handle->data1);
   guint8 *readbuf = (guint8 *)(handle->data2);
   guint8 *i8p;
-  int i;
+  guint i;
 
   lilendian = (ipatch_sample_store_get_format (split24_store)
 	       & IPATCH_SAMPLE_ENDIAN_MASK) == IPATCH_SAMPLE_LENDIAN;
@@ -200,7 +200,7 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
 
     if (lilendian)
     {
-      for (i = 0; (guint)i < thissize; i++)
+      for (i = 0; i < thissize; i++)
       {
         i8p[i * 4 + 1] = readbuf[i * 2];
         i8p[i * 4 + 2] = readbuf[i * 2 + 1];
@@ -209,7 +209,7 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
     }
     else
     {
-      for (i = 0; (guint)i < thissize; i++)
+      for (i = 0; i < thissize; i++)
       {
         i8p[i * 4 + 2] = readbuf[i * 2];
         i8p[i * 4 + 1] = readbuf[i * 2 + 1];
@@ -241,12 +241,12 @@ ipatch_sample_store_split24_sample_iface_read (IpatchSampleHandle *handle,
 
     if (lilendian)
     {
-      for (i = 0; (guint)i < thissize; i++)
+      for (i = 0; i < thissize; i++)
         i8p[i * 4] = readbuf[i];
     }
     else
     {
-      for (i = 0; (guint)i < thissize; i++)
+      for (i = 0; i < thissize; i++)
         i8p[i * 4 + 3] = readbuf[i];
     }
 

--- a/libinstpatch/IpatchSampleStoreSwap.c
+++ b/libinstpatch/IpatchSampleStoreSwap.c
@@ -45,6 +45,10 @@
 
 #ifdef _WIN32
 #include <io.h>
+#define lseek _lseek
+#define read _read
+#define write _write
+#define close _close
 #else
 #include <unistd.h>
 #endif

--- a/libinstpatch/IpatchSampleStoreSwap.c
+++ b/libinstpatch/IpatchSampleStoreSwap.c
@@ -632,9 +632,9 @@ ipatch_compact_sample_store_swap (GError **err)
   int newfd;
   GArray *position_array;
   GSList *p;
-  guint size, ofs, this_size;
-  int retval;
-  int i;
+  guint size, ofs;
+  int retval, this_size;
+  guint i;
 
   g_return_val_if_fail (!err || !*err, FALSE);
 
@@ -696,7 +696,7 @@ ipatch_compact_sample_store_swap (GError **err)
                      _("Error reading from sample store swap file: %s"), g_strerror (errno));
         goto error;
       }
-      else if ((guint)retval < this_size)
+      else if (retval < this_size)
       {
         g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
                      _("Short read from sample store swap file, expected %d but got %d"),
@@ -712,7 +712,7 @@ ipatch_compact_sample_store_swap (GError **err)
                      _("Error writing to new sample store swap file: %s"), g_strerror (errno));
         goto error;
       }
-      else if ((guint)retval < this_size)
+      else if (retval < this_size)
       {
         g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
                      _("Short write to new sample store swap file, expected %d but got %d"),
@@ -745,7 +745,7 @@ ipatch_compact_sample_store_swap (GError **err)
   }
 
   // Fixup locations
-  for (i = 0, p = swap_list; (guint)i < position_array->len; i++, p = p->next)
+  for (i = 0, p = swap_list; i < position_array->len; i++, p = p->next)
   {
     store = (IpatchSampleStoreSwap *)(p->data);
     store->location = g_array_index (position_array, guint, i);

--- a/libinstpatch/IpatchSampleStoreSwap.c
+++ b/libinstpatch/IpatchSampleStoreSwap.c
@@ -243,7 +243,7 @@ ipatch_sample_store_swap_sample_iface_open (IpatchSampleHandle *handle,
     // Check if allocating sample in RAM would exceed max allowed
     if (new_ram_used > g_atomic_int_get (&swap_ram_max))
     { // RAM swap is maxed out - correct swap_ram_used
-      g_atomic_int_add (&swap_ram_used, -sample_size);
+      g_atomic_int_add (&swap_ram_used, -(gint)sample_size);
 
       if (swap_fd == -1)   /* Swap file not yet created? */
         ipatch_sample_store_swap_open_file ();
@@ -267,7 +267,7 @@ ipatch_sample_store_swap_sample_iface_open (IpatchSampleHandle *handle,
 
           recover->size -= sample_size;
           recover->location += sample_size;
-          g_atomic_int_add (&swap_unused_size, -sample_size);
+          g_atomic_int_add (&swap_unused_size, -(gint)sample_size);
 
           // Remove the node from the size recover list
           if (prevprev) prevprev->next = prev->next;
@@ -462,7 +462,7 @@ ipatch_sample_store_swap_finalize (GObject *gobject)
 
   if (store->ram_location)                      // Allocated in RAM?
   {
-    g_atomic_int_add (&swap_ram_used, -size);   // Subtract size from RAM usage
+    g_atomic_int_add (&swap_ram_used, -(gint)size);   // Subtract size from RAM usage
     g_free (store->ram_location);               // -- free allocated RAM
   }
   else
@@ -692,7 +692,7 @@ ipatch_compact_sample_store_swap (GError **err)
                      _("Error reading from sample store swap file: %s"), g_strerror (errno));
         goto error;
       }
-      else if (retval < this_size)
+      else if ((guint)retval < this_size)
       {
         g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
                      _("Short read from sample store swap file, expected %d but got %d"),
@@ -708,7 +708,7 @@ ipatch_compact_sample_store_swap (GError **err)
                      _("Error writing to new sample store swap file: %s"), g_strerror (errno));
         goto error;
       }
-      else if (retval < this_size)
+      else if ((guint)retval < this_size)
       {
         g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
                      _("Short write to new sample store swap file, expected %d but got %d"),
@@ -741,7 +741,7 @@ ipatch_compact_sample_store_swap (GError **err)
   }
 
   // Fixup locations
-  for (i = 0, p = swap_list; i < position_array->len; i++, p = p->next)
+  for (i = 0, p = swap_list; (guint)i < position_array->len; i++, p = p->next)
   {
     store = (IpatchSampleStoreSwap *)(p->data);
     store->location = g_array_index (position_array, guint, i);

--- a/libinstpatch/IpatchSampleStoreVirtual.c
+++ b/libinstpatch/IpatchSampleStoreVirtual.c
@@ -105,7 +105,7 @@ ipatch_sample_store_virtual_set_property (GObject *object, guint property_id,
 
       for (chan = 0; chan < 2; chan++)
       {
-        if (array && chan < array->n_values)
+        if (array && (guint)chan < array->n_values)
           list = g_value_dup_boxed (g_value_array_get_nth (array, chan));
         else list = NULL;
 
@@ -228,7 +228,7 @@ ipatch_sample_store_virtual_sample_iface_read (IpatchSampleHandle *handle,
 
   while (frames > 0)
   {
-    if (block > frames) block = frames;
+    if ((guint)block > frames) block = frames;
 
     if (!ipatch_sample_list_render (store->lists[0], interbuf, offset, block, format, err))
       return (FALSE);

--- a/libinstpatch/IpatchSampleStoreVirtual.c
+++ b/libinstpatch/IpatchSampleStoreVirtual.c
@@ -96,7 +96,7 @@ ipatch_sample_store_virtual_set_property (GObject *object, guint property_id,
   IpatchSampleStoreVirtual *store = IPATCH_SAMPLE_STORE_VIRTUAL (object);
   IpatchSampleList *list;
   GValueArray *array;
-  int chan;
+  guint chan;
 
   switch (property_id)
   {
@@ -105,7 +105,7 @@ ipatch_sample_store_virtual_set_property (GObject *object, guint property_id,
 
       for (chan = 0; chan < 2; chan++)
       {
-        if (array && (guint)chan < array->n_values)
+        if (array && chan < array->n_values)
           list = g_value_dup_boxed (g_value_array_get_nth (array, chan));
         else list = NULL;
 
@@ -210,8 +210,7 @@ ipatch_sample_store_virtual_sample_iface_read (IpatchSampleHandle *handle,
   guint16 *wbuf, *wleft, *wright;
   guint32 *dbuf, *dleft, *dright;
   guint64 *qbuf, *qleft, *qright;
-  int mi, si;
-  int block;
+  guint block, mi, si;
 
   if (!interbuf)   /* Store is mono? - Just render it */
   {
@@ -228,7 +227,7 @@ ipatch_sample_store_virtual_sample_iface_read (IpatchSampleHandle *handle,
 
   while (frames > 0)
   {
-    if ((guint)block > frames) block = frames;
+    if (block > frames) block = frames;
 
     if (!ipatch_sample_list_render (store->lists[0], interbuf, offset, block, format, err))
       return (FALSE);

--- a/libinstpatch/IpatchSampleTransform.c
+++ b/libinstpatch/IpatchSampleTransform.c
@@ -497,7 +497,8 @@ gpointer
 ipatch_sample_transform_convert (IpatchSampleTransform *transform,
 				 gconstpointer src, gpointer dest, guint frames)
 {
-  int i, func_count, block_size;
+  int i, func_count;
+  guint  block_size;
   gpointer buf1, buf2;
   int src_frame_size, dest_frame_size, srcchan;
 
@@ -532,7 +533,7 @@ ipatch_sample_transform_convert (IpatchSampleTransform *transform,
 
   while (frames > 0)
   {
-    if ((guint)block_size > frames) block_size = frames;
+    if (block_size > frames) block_size = frames;
 
     transform->frames = block_size;
     transform->samples = block_size * srcchan;

--- a/libinstpatch/IpatchSampleTransform.c
+++ b/libinstpatch/IpatchSampleTransform.c
@@ -532,7 +532,7 @@ ipatch_sample_transform_convert (IpatchSampleTransform *transform,
 
   while (frames > 0)
   {
-    if (block_size > frames) block_size = frames;
+    if ((guint)block_size > frames) block_size = frames;
 
     transform->frames = block_size;
     transform->samples = block_size * srcchan;

--- a/libinstpatch/IpatchSndFile.c
+++ b/libinstpatch/IpatchSndFile.c
@@ -244,9 +244,9 @@ ipatch_snd_file_format_get_sub_formats (int format, guint *size)
 int
 ipatch_snd_file_sample_format_to_sub_format (int sample_format, int file_format)
 {
-  int sub_format, i;
+  int sub_format;
   int *formats;
-  guint size;
+  guint i,size;
   
   g_return_val_if_fail (ipatch_sample_format_verify (sample_format), -1);
 
@@ -282,7 +282,7 @@ ipatch_snd_file_sample_format_to_sub_format (int sample_format, int file_format)
 
     if (!formats) return (-1);  /* Invalid file_format value */
 
-    for (i = 0; (guint)i < size; i++)
+    for (i = 0; i < size; i++)
       if (formats[i] == sub_format)
         break;
 

--- a/libinstpatch/IpatchSndFile.c
+++ b/libinstpatch/IpatchSndFile.c
@@ -282,7 +282,7 @@ ipatch_snd_file_sample_format_to_sub_format (int sample_format, int file_format)
 
     if (!formats) return (-1);  /* Invalid file_format value */
 
-    for (i = 0; i < size; i++)
+    for (i = 0; (guint)i < size; i++)
       if (formats[i] == sub_format)
         break;
 

--- a/libinstpatch/IpatchUnit_DLS.c
+++ b/libinstpatch/IpatchUnit_DLS.c
@@ -235,7 +235,7 @@ ipatch_unit_dls_percent_to_percent (int dls_percent)
 int
 ipatch_unit_percent_to_dls_percent (double percent)
 {
-  return (percent * 655360.0 + 0.5);	/* +0.5 for rounding */
+  return (int)(percent * 655360.0 + 0.5);	/* +0.5 for rounding */
 }
 
 /**
@@ -267,7 +267,7 @@ ipatch_unit_dls_gain_to_decibels (int dls_gain)
 int
 ipatch_unit_decibels_to_dls_gain (double db)
 {
-  return (db * 655360.0 + 0.5);
+  return (int)(db * 655360.0 + 0.5);
 }
 
 /**
@@ -304,7 +304,7 @@ ipatch_unit_seconds_to_dls_abs_time (double seconds)
 {
   if (seconds == 0.0) return (IPATCH_UNIT_DLS_ABS_TIME_0SECS);
 
-  return ((double)1200.0 * (log (seconds) / log (2.0)) * 65536.0 + 0.5);
+  return (gint32)((double)1200.0 * (log (seconds) / log (2.0)) * 65536.0 + 0.5);
 }
 
 /**
@@ -334,7 +334,7 @@ ipatch_unit_dls_rel_time_to_time_cents (int dls_rel_time)
 int
 ipatch_unit_time_cents_to_dls_rel_time (double time_cents)
 {
-  return (time_cents * 65536.0 + 0.5);
+  return (int)(time_cents * 65536.0 + 0.5);
 }
 
 /**
@@ -364,7 +364,7 @@ ipatch_unit_dls_abs_pitch_to_hertz (int dls_abs_pitch)
 int
 ipatch_unit_hertz_to_dls_abs_pitch (double hertz)
 {
-  return (((double)1200.0 * (log (hertz / 440.0) / log (2)) + 6900.0) * 65536.0 + 0.5);
+  return (int)(((double)1200.0 * (log (hertz / 440.0) / log (2)) + 6900.0) * 65536.0 + 0.5);
 }
 
 /**
@@ -394,7 +394,7 @@ ipatch_unit_dls_rel_pitch_to_cents (int dls_rel_pitch)
 int
 ipatch_unit_cents_to_dls_rel_pitch (double cents)
 {
-  return (cents * 65536.0 + 0.5);
+  return (int)(cents * 65536.0 + 0.5);
 }
 
 
@@ -416,7 +416,7 @@ ipatch_unit_percent_to_dls_percent_value (const GValue *src_val,
 					  GValue *dest_val)
 {
   double percent = g_value_get_double (src_val);
-  g_value_set_int (dest_val, percent * 655360.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(percent * 655360.0 + 0.5));
 }
 
 static void
@@ -430,7 +430,7 @@ static void
 ipatch_unit_decibels_to_dls_gain_value (const GValue *src_val, GValue *dest_val)
 {
   double db = g_value_get_double (src_val);
-  g_value_set_int (dest_val, db * 655360.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(db * 655360.0 + 0.5));
 }
 
 static void
@@ -455,7 +455,7 @@ ipatch_unit_seconds_to_dls_abs_time_value (const GValue *src_val,
   int dls_abs_time;
 
   if (secs != 0.0)
-    dls_abs_time = (double)1200.0 * (log (secs) / log (2.0)) * 65536.0 + 0.5;
+    dls_abs_time = (int)((double)1200.0 * (log (secs) / log (2.0)) * 65536.0 + 0.5);
   else dls_abs_time = IPATCH_UNIT_DLS_ABS_TIME_0SECS;
 
   g_value_set_int (dest_val, dls_abs_time);
@@ -474,7 +474,7 @@ ipatch_unit_time_cents_to_dls_rel_time_value (const GValue *src_val,
 					      GValue *dest_val)
 {
   double time_cents = g_value_get_double (src_val);
-  g_value_set_int (dest_val, time_cents * 65536.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(time_cents * 65536.0 + 0.5));
 }
 
 static void
@@ -491,8 +491,8 @@ ipatch_unit_hertz_to_dls_abs_pitch_value (const GValue *src_val,
 					  GValue *dest_val)
 {
   double hertz = g_value_get_double (src_val);
-  g_value_set_int (dest_val, ((double)1200.0 * (log (hertz / 440.0) / log (2))
-			      + 6900.0) * 65536.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(((double)1200.0 * (log (hertz / 440.0) / log (2))
+			      + 6900.0) * 65536.0 + 0.5));
 }
 
 static void
@@ -508,5 +508,5 @@ ipatch_unit_cents_to_dls_rel_pitch_value (const GValue *src_val,
 					  GValue *dest_val)
 {
   double cents = g_value_get_double (src_val);
-  g_value_set_int (dest_val, cents * 65536.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(cents * 65536.0 + 0.5));
 }

--- a/libinstpatch/IpatchUnit_SF2.c
+++ b/libinstpatch/IpatchUnit_SF2.c
@@ -248,7 +248,7 @@ ipatch_unit_sf2_abs_pitch_to_dls_abs_pitch (int sf2_abs_pitch)
   double hz;
 
   hz = 8.176 * pow (2.0, ((double)sf2_abs_pitch) / 1200.0);
-  return ((1200.0 * (log (hz / 440.0) / log (2.0)) + 6900.0)
+  return (int)((1200.0 * (log (hz / 440.0) / log (2.0)) + 6900.0)
 	  * 65536.0 + 0.5);	/* +0.5 for rounding */
 }
 
@@ -268,7 +268,7 @@ ipatch_unit_dls_abs_pitch_to_sf2_abs_pitch (int dls_abs_pitch)
 
   hz = 440.0 * pow (2.0, (((double)dls_abs_pitch / 65536.0 - 6900.0)
 			  / 1200.0));
-  return (1200.0 * (log (hz / 8.176) / log (2.0)) + 0.5); /* +0.5 to round */
+  return (int)(1200.0 * (log (hz / 8.176) / log (2.0)) + 0.5); /* +0.5 to round */
 }
 
 /**
@@ -296,7 +296,7 @@ ipatch_unit_sf2_abs_pitch_to_hertz (int sf2_abs_pitch)
 int
 ipatch_unit_hertz_to_sf2_abs_pitch (double hz)
 {
-  return (log (hz / 8.176) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
+  return (int)(log (hz / 8.176) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
 }
 
 /**
@@ -324,7 +324,7 @@ ipatch_unit_sf2_ofs_pitch_to_multiplier (int sf2_ofs_pitch)
 int
 ipatch_unit_multiplier_to_sf2_ofs_pitch (double multiplier)
 {
-  return (log (multiplier) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
+  return (int)(log (multiplier) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
 }
 
 /**
@@ -387,7 +387,7 @@ ipatch_unit_sf2_abs_time_to_seconds (int sf2_abs_time)
 int
 ipatch_unit_seconds_to_sf2_abs_time (double sec)
 {
-  return (log (sec) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
+  return (int)(log (sec) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
 }
 
 /**
@@ -415,7 +415,7 @@ ipatch_unit_sf2_ofs_time_to_multiplier (int sf2_ofs_time)
 int
 ipatch_unit_multiplier_to_sf2_ofs_time (double multiplier)
 {
-  return (log (multiplier) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
+  return (int)(log (multiplier) / log (2) * 1200 + 0.5); /* +0.5 for rounding */
 }
 
 /**
@@ -475,7 +475,7 @@ ipatch_unit_centibels_to_decibels (int cb)
 int
 ipatch_unit_decibels_to_centibels (double db)
 {
-  return (db * 10.0 + 0.5);	/* +0.5 for rounding */
+  return (int)(db * 10.0 + 0.5);	/* +0.5 for rounding */
 }
 
 /**
@@ -503,7 +503,7 @@ ipatch_unit_tenth_percent_to_percent (int tenth_percent)
 int
 ipatch_unit_percent_to_tenth_percent (double percent)
 {
-  return (percent * 10.0 + 0.5);	/* +0.5 for rounding */
+  return (int)(percent * 10.0 + 0.5);	/* +0.5 for rounding */
 }
 
 /* =================================================
@@ -553,7 +553,7 @@ ipatch_unit_hertz_to_sf2_abs_pitch_value (const GValue *src_val,
 					  GValue *dest_val)
 {
   double hz = g_value_get_double (src_val);
-  g_value_set_int (dest_val, log (hz / 8.176) / log (2) * 1200 + 0.5);
+  g_value_set_int (dest_val, (gint)(log (hz / 8.176) / log (2) * 1200 + 0.5));
 }
 
 static void
@@ -585,7 +585,7 @@ ipatch_unit_seconds_to_sf2_abs_time_value (const GValue *src_val,
 					   GValue *dest_val)
 {
   double sec = g_value_get_double (src_val);
-  g_value_set_int (dest_val, log (sec) / log (2) * 1200 + 0.5);
+  g_value_set_int (dest_val, (gint)(log (sec) / log (2) * 1200 + 0.5));
 }
 
 static void
@@ -617,7 +617,7 @@ ipatch_unit_decibels_to_centibels_value (const GValue *src_val,
 					 GValue *dest_val)
 {
   double db = g_value_get_double (src_val);
-  g_value_set_int (dest_val, db * 10.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(db * 10.0 + 0.5));
 }
 
 static void
@@ -633,5 +633,5 @@ ipatch_unit_percent_to_tenth_percent_value (const GValue *src_val,
 					    GValue *dest_val)
 {
   double percent = g_value_get_double (src_val);
-  g_value_set_int (dest_val, percent * 10.0 + 0.5);
+  g_value_set_int (dest_val, (gint)(percent * 10.0 + 0.5));
 }

--- a/libinstpatch/IpatchVBank.c
+++ b/libinstpatch/IpatchVBank.c
@@ -305,7 +305,7 @@ ipatch_vbank_base_find_unused_locale (IpatchBase *base, int *bank,
   GSList *locale_list = NULL;
   IpatchVBankInst *inst;
   GSList *p;
-  int b, n;			/* Stores current bank and program number */
+  guint b, n;			/* Stores current bank and program number */
   guint lbank, lprogram;
 
   /* fill array with bank and program numbers */
@@ -339,8 +339,8 @@ ipatch_vbank_base_find_unused_locale (IpatchBase *base, int *bank,
     lbank = lprogram >> 16;
     lprogram &= 0xFFFF;
 
-    if (lbank > (guint)b || (lbank == b && lprogram > (guint)n)) break;
-    if (lbank >= (guint)b)
+    if (lbank > b || (lbank == b && lprogram > n)) break;
+    if (lbank >= b)
     {
       if (++n > 127)
       {

--- a/libinstpatch/IpatchVBank.c
+++ b/libinstpatch/IpatchVBank.c
@@ -339,8 +339,8 @@ ipatch_vbank_base_find_unused_locale (IpatchBase *base, int *bank,
     lbank = lprogram >> 16;
     lprogram &= 0xFFFF;
 
-    if (lbank > b || (lbank == b && lprogram > n)) break;
-    if (lbank >= b)
+    if (lbank > (guint)b || (lbank == b && lprogram > (guint)n)) break;
+    if (lbank >= (guint)b)
     {
       if (++n > 127)
       {

--- a/libinstpatch/IpatchVBankRegion.c
+++ b/libinstpatch/IpatchVBankRegion.c
@@ -144,7 +144,7 @@ ipatch_vbank_region_set_property (GObject *object, guint property_id,
   GValueArray *valarray;
   IpatchRange *range;
   char **strv;
-  int i;
+  guint i;
 
   switch (property_id)
   {
@@ -160,7 +160,7 @@ ipatch_vbank_region_set_property (GObject *object, guint property_id,
       {
 	strv = g_new (char *, valarray->n_values + 1);	/* ++ alloc */
 
-	for (i = 0; (guint)i < valarray->n_values; i++)
+	for (i = 0; i < valarray->n_values; i++)
 	  strv[i] = (char *)g_value_get_string (g_value_array_get_nth (valarray, i));
 
 	strv[valarray->n_values] = NULL;
@@ -202,7 +202,7 @@ ipatch_vbank_region_get_property (GObject *object, guint property_id,
   guint n_elements;
   char **strv;
   GValue val = { 0 };
-  int i;
+  guint i;
 
   switch (property_id)
   {
@@ -220,7 +220,7 @@ ipatch_vbank_region_get_property (GObject *object, guint property_id,
 	valarray = g_value_array_new (n_elements);	/* ++ alloc */
 	g_value_init (&val, G_TYPE_STRING);
 
-	for (i = 0; (guint)i < n_elements; i++)
+	for (i = 0; i < n_elements; i++)
 	{
 	  g_value_set_string (&val, strv[i]);	/* ++ alloc */
 	  g_value_array_append (valarray, &val);

--- a/libinstpatch/IpatchVBankRegion.c
+++ b/libinstpatch/IpatchVBankRegion.c
@@ -160,7 +160,7 @@ ipatch_vbank_region_set_property (GObject *object, guint property_id,
       {
 	strv = g_new (char *, valarray->n_values + 1);	/* ++ alloc */
 
-	for (i = 0; i < valarray->n_values; i++)
+	for (i = 0; (guint)i < valarray->n_values; i++)
 	  strv[i] = (char *)g_value_get_string (g_value_array_get_nth (valarray, i));
 
 	strv[valarray->n_values] = NULL;
@@ -220,7 +220,7 @@ ipatch_vbank_region_get_property (GObject *object, guint property_id,
 	valarray = g_value_array_new (n_elements);	/* ++ alloc */
 	g_value_init (&val, G_TYPE_STRING);
 
-	for (i = 0; i < n_elements; i++)
+	for (i = 0; (guint)i < n_elements; i++)
 	{
 	  g_value_set_string (&val, strv[i]);	/* ++ alloc */
 	  g_value_array_append (valarray, &val);

--- a/libinstpatch/IpatchXml.c
+++ b/libinstpatch/IpatchXml.c
@@ -182,7 +182,7 @@ void
 ipatch_xml_set_data (GNode *node, const char *key, gpointer data)
 {
   g_return_if_fail (node != NULL);
-  return (g_datalist_set_data (QDATA (node), key, data));
+  g_datalist_set_data (QDATA (node), key, data);
 }
 
 /**
@@ -200,7 +200,7 @@ ipatch_xml_set_data_full (GNode *node, const char *key, gpointer data,
                           GDestroyNotify destroy_func)
 {
   g_return_if_fail (node != NULL);
-  return (g_datalist_set_data_full (QDATA (node), key, data, destroy_func));
+  g_datalist_set_data_full (QDATA (node), key, data, destroy_func);
 }
 
 /**
@@ -261,7 +261,7 @@ void
 ipatch_xml_set_qdata (GNode *node, GQuark quark, gpointer data)
 {
   g_return_if_fail (node != NULL);
-  return (g_datalist_id_set_data (QDATA (node), quark, data));
+  g_datalist_id_set_data (QDATA (node), quark, data);
 }
 
 /**
@@ -281,7 +281,7 @@ ipatch_xml_set_qdata_full (GNode *node, GQuark quark, gpointer data,
                            GDestroyNotify destroy_func)
 {
   g_return_if_fail (node != NULL);
-  return (g_datalist_id_set_data_full (QDATA (node), quark, data, destroy_func));
+  g_datalist_id_set_data_full (QDATA (node), quark, data, destroy_func);
 }
 
 /**
@@ -783,7 +783,7 @@ ipatch_xml_to_str_recurse (GString *str, GNode *node, guint indent, guint inc)
 
   xmlnode = (IpatchXmlNode *)(node->data);
 
-  for (i = 0; i < indent; i++)
+  for (i = 0; (guint)i < indent; i++)
     g_string_append_c (str, ' ');
 
   g_string_append_printf (str, "<%s", xmlnode->name);
@@ -823,7 +823,7 @@ ipatch_xml_to_str_recurse (GString *str, GNode *node, guint indent, guint inc)
     for (n = node->children; n; n = n->next)
       ipatch_xml_to_str_recurse (str, n, indent + inc, inc);
 
-    for (i = 0; i < indent; i++)
+    for (i = 0; (guint)i < indent; i++)
       g_string_append_c (str, ' ');
   }
 

--- a/libinstpatch/IpatchXml.c
+++ b/libinstpatch/IpatchXml.c
@@ -779,11 +779,11 @@ ipatch_xml_to_str_recurse (GString *str, GNode *node, guint indent, guint inc)
   IpatchXmlNode *xmlnode;
   char *esc;
   GNode *n;
-  int i;
+  guint i;
 
   xmlnode = (IpatchXmlNode *)(node->data);
 
-  for (i = 0; (guint)i < indent; i++)
+  for (i = 0; i < indent; i++)
     g_string_append_c (str, ' ');
 
   g_string_append_printf (str, "<%s", xmlnode->name);
@@ -823,7 +823,7 @@ ipatch_xml_to_str_recurse (GString *str, GNode *node, guint indent, guint inc)
     for (n = node->children; n; n = n->next)
       ipatch_xml_to_str_recurse (str, n, indent + inc, inc);
 
-    for (i = 0; (guint)i < indent; i++)
+    for (i = 0; i < indent; i++)
       g_string_append_c (str, ' ');
   }
 

--- a/libinstpatch/sample.c
+++ b/libinstpatch/sample.c
@@ -56,7 +56,7 @@ void TFF_ ## NAME (IpatchSampleTransform *transform) \
 /* float transforms */
 
 TRANS_FUNC (floattodouble, gfloat, gdouble, NOP, { outp[i] = inp[i]; }, NOP)
-TRANS_FUNC (doubletofloat, gdouble, gfloat, NOP, { outp[i] = inp[i]; }, NOP)
+TRANS_FUNC (doubletofloat, gdouble, gfloat, NOP, { outp[i] = (gfloat)inp[i]; }, NOP)
 
 
 /* signed bit width change funcs */
@@ -94,22 +94,22 @@ TRANS_FUNC (s32todouble, gint32, gdouble, NOP,
             { outp[i] = inp[i] / (double)2147483648.0; }, NOP)
 
 TRANS_FUNC (floattos8, gfloat, gint8, NOP,
-            { outp[i] = inp[i] * 127.0; }, NOP)
+            { outp[i] = (gint8)(inp[i] * 127.0); }, NOP)
 TRANS_FUNC (floattos16, gfloat, gint16, NOP,
-            { outp[i] = inp[i] * 32767.0; }, NOP)
+            { outp[i] = (gint16)(inp[i] * 32767.0); }, NOP)
 TRANS_FUNC (floattos24, gfloat, gint32, NOP,
-            { outp[i] = inp[i] * 8388607.0; }, NOP)
+            { outp[i] = (gint32)(inp[i] * 8388607.0); }, NOP)
 TRANS_FUNC (floattos32, gfloat, gint32, NOP,
-            { outp[i] = inp[i] * 2147483647.0; }, NOP)
+            { outp[i] = (gint32)(inp[i] * 2147483647.0); }, NOP)
 
 TRANS_FUNC (doubletos8, gdouble, gint8, NOP,
-            { outp[i] = inp[i] * 127.0; }, NOP)
+            { outp[i] = (gint8)(inp[i] * 127.0); }, NOP)
 TRANS_FUNC (doubletos16, gdouble, gint16, NOP,
-            { outp[i] = inp[i] * 32767.0; }, NOP)
+            { outp[i] = (gint16)(inp[i] * 32767.0); }, NOP)
 TRANS_FUNC (doubletos24, gdouble, gint32, NOP,
-            { outp[i] = inp[i] * 8388607.0; }, NOP)
+            { outp[i] = (gint32)(inp[i] * 8388607.0); }, NOP)
 TRANS_FUNC (doubletos32, gdouble, gint32, NOP,
-            { outp[i] = inp[i] * 2147483647.0; }, NOP)
+            { outp[i] = (gint32)(inp[i] * 2147483647.0); }, NOP)
 
 
 /* unsigned bit width change funcs */
@@ -147,22 +147,22 @@ TRANS_FUNC (u32todouble, guint32, gdouble, NOP,
             { outp[i] = (gint32)(inp[i] ^ 0x80000000) / (double)2147483648.0; }, NOP)
 
 TRANS_FUNC (floattou8, gfloat, guint8, NOP,
-            { outp[i] = (inp[i] + 1.0) * 127.5 + 0.5; }, NOP)
+            { outp[i] = (guint8)((inp[i] + 1.0) * 127.5 + 0.5); }, NOP)
 TRANS_FUNC (floattou16, gfloat, guint16, NOP,
-            { outp[i] = (inp[i] + 1.0) * 32767.5 + 0.5; }, NOP)
+            { outp[i] = (guint16)((inp[i] + 1.0) * 32767.5 + 0.5); }, NOP)
 TRANS_FUNC (floattou24, gfloat, guint32, NOP,
-            { outp[i] = (inp[i] + 1.0) * 8388607.5 + 0.5; }, NOP)
+            { outp[i] = (guint32)((inp[i] + 1.0) * 8388607.5 + 0.5); }, NOP)
 TRANS_FUNC (floattou32, gfloat, guint32, NOP,
-            { outp[i] = (inp[i] + 1.0) * 2147483647.5 + 0.5; }, NOP)
+            { outp[i] = (guint32)((inp[i] + 1.0) * 2147483647.5 + 0.5); }, NOP)
 
 TRANS_FUNC (doubletou8, gdouble, guint8, NOP,
-            { outp[i] = (inp[i] + 1.0) * 127.5 + 0.5; }, NOP)
+            { outp[i] = (guint8)((inp[i] + 1.0) * 127.5 + 0.5); }, NOP)
 TRANS_FUNC (doubletou16, gdouble, guint16, NOP,
-            { outp[i] = (inp[i] + 1.0) * 32767.5 + 0.5; }, NOP)
+            { outp[i] = (guint16)((inp[i] + 1.0) * 32767.5 + 0.5); }, NOP)
 TRANS_FUNC (doubletou24, gdouble, guint32, NOP,
-            { outp[i] = (inp[i] + 1.0) * 8388607.5 + 0.5; }, NOP)
+            { outp[i] = (guint32)((inp[i] + 1.0) * 8388607.5 + 0.5); }, NOP)
 TRANS_FUNC (doubletou32, gdouble, guint32, NOP,
-            { outp[i] = (inp[i] + 1.0) * 2147483647.5 + 0.5; }, NOP)
+            { outp[i] = (guint32)((inp[i] + 1.0) * 2147483647.5 + 0.5); }, NOP)
 
 
 /* sign changer funcs (24 bit in 4 byte integers requires 2 separate funcs) */
@@ -475,7 +475,7 @@ ipatch_sample_format_transform_verify (int src_format, int dest_format,
   dest_chans = IPATCH_SAMPLE_FORMAT_GET_CHANNEL_COUNT (dest_format);
 
   for (i = 0; i < dest_chans; i++)
-    if (((channel_map >> (i * 3)) & 0x07) >= src_chans)
+    if (((channel_map >> (i * 3)) & 0x07) >= (guint32)src_chans)
       return (FALSE);
 
   return (TRUE);

--- a/libinstpatch/util.c
+++ b/libinstpatch/util.c
@@ -171,12 +171,12 @@ ipatch_util_value_array_hash (GValueArray *valarray)
 guint64
 ipatch_util_file_size (const char *fname, GError **err)
 {
-  struct stat st;
+  GStatBuf st;
 
   g_return_val_if_fail (fname != NULL, 0);
   g_return_val_if_fail (!err || !*err, 0);
 
-  if (g_stat (fname, (GStatBuf *)&st) != 0)
+  if (g_stat (fname, &st) != 0)
     {
       g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
 		   _("Error stating file '%s': %s"), fname, g_strerror (errno));

--- a/libinstpatch/util.c
+++ b/libinstpatch/util.c
@@ -95,9 +95,9 @@ ipatch_util_value_hash (GValue *val)
     case G_TYPE_ULONG:
       return (g_value_get_ulong (val));
     case G_TYPE_INT64:
-      return (g_value_get_int64 (val));
+      return (guint)(g_value_get_int64 (val));
     case G_TYPE_UINT64:
-      return (g_value_get_uint64 (val));
+      return (guint)(g_value_get_uint64 (val));
     case G_TYPE_ENUM:
       return (g_value_get_enum (val));
     case G_TYPE_FLAGS:
@@ -106,7 +106,7 @@ ipatch_util_value_hash (GValue *val)
       fval.f = g_value_get_float (val);
       return (fval.i);	/* use the raw float data as hash */
     case G_TYPE_DOUBLE:
-      fval.f = g_value_get_double (val);	/* convert double to float */
+      fval.f = (gfloat)g_value_get_double (val);	/* convert double to float */
       return (fval.i);		/* use the raw float data as hash */
     case G_TYPE_STRING:
       sval = g_value_get_string (val);
@@ -149,7 +149,7 @@ ipatch_util_value_array_hash (GValueArray *valarray)
 
   if (!valarray) return (0);
 
-  for (i = 0; i < valarray->n_values; i++)
+  for (i = 0; (guint)i < valarray->n_values; i++)
     {
       value = g_value_array_get_nth (valarray, i);
       hashval += ipatch_util_value_hash (value);
@@ -176,7 +176,7 @@ ipatch_util_file_size (const char *fname, GError **err)
   g_return_val_if_fail (fname != NULL, 0);
   g_return_val_if_fail (!err || !*err, 0);
 
-  if (g_stat (fname, &st) != 0)
+  if (g_stat (fname, (GStatBuf *)&st) != 0)
     {
       g_set_error (err, IPATCH_ERROR, IPATCH_ERROR_IO,
 		   _("Error stating file '%s': %s"), fname, g_strerror (errno));

--- a/libinstpatch/util.c
+++ b/libinstpatch/util.c
@@ -145,11 +145,11 @@ ipatch_util_value_array_hash (GValueArray *valarray)
 {
   GValue *value;
   guint hashval = 0;
-  int i;
+  guint i;
 
   if (!valarray) return (0);
 
-  for (i = 0; (guint)i < valarray->n_values; i++)
+  for (i = 0; i < valarray->n_values; i++)
     {
       value = g_value_array_get_nth (valarray, i);
       hashval += ipatch_util_value_hash (value);


### PR DESCRIPTION
1) adding a global definition for Windows to suppress deprecated functions warnings.
2)Cleanup a bunch of warning mainly by setting explicit casting:
- explicit cast on signed/unsigned.
- explicit cast when reducing format (i.e double to float).
3)removing return value on function defined `void function()`
4)renaming Windows i/o files functions.
