### PR TITLE
Configure O.S includes files at Cmake time:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ check_include_file ( stdarg.h HAVE_STDARG_H )
 check_include_file ( unistd.h HAVE_UNISTD_H )
 
 if ( WIN32 )
-  include ( CheckIncludeFiles )
   # Check presence of MS include files
   check_include_file ( io.h HAVE_IO_H )
 endif( WIN32 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,14 @@ check_include_file ( stdio.h HAVE_STDIO_H )
 check_include_file ( math.h HAVE_MATH_H ) 
 check_include_file ( errno.h HAVE_ERRNO_H ) 
 check_include_file ( stdarg.h HAVE_STDARG_H ) 
-check_include_file ( unistd.h HAVE_UNISTD_H ) 
+check_include_file ( unistd.h HAVE_UNISTD_H )
+
+if ( WIN32 )
+  include ( CheckIncludeFiles )
+  # Check presence of MS include files
+  check_include_file ( io.h HAVE_IO_H )
+endif( WIN32 )
+
 
 unset ( IPATCH_CPPFLAGS CACHE )
 unset ( IPATCH_LIBS CACHE )

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -7,6 +7,9 @@
 /* Define to 1 if you have the <fcntl.h> header file. */
 #cmakedefine HAVE_FCNTL_H @HAVE_FCNTL_H@
 
+/* Define to 1 if you have the <io.h> header file. */
+#cmakedefine HAVE_IO_H @HAVE_IO_H@
+
 /* Define to 1 if you have the <math.h> header file. */
 #cmakedefine HAVE_MATH_H @HAVE_MATH_H@
 

--- a/libinstpatch/IpatchFile.c
+++ b/libinstpatch/IpatchFile.c
@@ -33,12 +33,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-
 #include <glib.h>
 #include <glib/gstdio.h>
 #include <glib-object.h>

--- a/libinstpatch/IpatchSF2Reader.c
+++ b/libinstpatch/IpatchSF2Reader.c
@@ -31,12 +31,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-
 #include <errno.h>
 
 #include "IpatchSF2Reader.h"

--- a/libinstpatch/IpatchSLIReader.c
+++ b/libinstpatch/IpatchSLIReader.c
@@ -33,14 +33,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-
-#include <errno.h>
-
 #include "IpatchRiff.h"
 #include "IpatchSLIReader.h"
 #include "IpatchSampleStore.h"

--- a/libinstpatch/IpatchSample.c
+++ b/libinstpatch/IpatchSample.c
@@ -27,12 +27,6 @@
  */
 #include <stdio.h>
 
-#ifdef _WIN32
-#include <io.h>
-#else
-#include <unistd.h>
-#endif
-
 #include <string.h>
 #include <glib.h>
 #include <glib-object.h>

--- a/libinstpatch/IpatchSampleStoreSwap.c
+++ b/libinstpatch/IpatchSampleStoreSwap.c
@@ -375,7 +375,7 @@ ipatch_sample_store_swap_sample_iface_read (IpatchSampleHandle *handle,
 
   G_LOCK (swap);        // ++ lock swap
 
-  if (_lseek (swap_fd, store->location + offset * frame_size, SEEK_SET) == -1)
+  if (IPATCH_FD_LSEEK (swap_fd, store->location + offset * frame_size, SEEK_SET) == -1)
   {
     G_UNLOCK (swap);    // -- unlock swap
     g_set_error (err, G_FILE_ERROR, g_file_error_from_errno (errno),

--- a/libinstpatch/ipatch_priv.h
+++ b/libinstpatch/ipatch_priv.h
@@ -31,20 +31,33 @@
 
 #if HAVE_IO_H
 #include <io.h> // _lseek(), _close(), _read(), _write() on windows
-#define IPATCH_FD_LSEEK(fd, offset,origin) _lseek(fd, offset, origin)
-#define IPATCH_FD_READ(fd, bufdst, count)  _read(fd, bufdst, count)
-#define IPATCH_FD_WRITE(fd, bufsrc, count) _write(fd, bufsrc, count)
-#define IPATCH_FD_CLOSE(fd) _close(fd)
 #endif
 
 #if HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+
+/*
+   In case of cross compiling from Linux to Win32, unistd.h and io.h
+   may be both present.
+   So, we provide here exclusive macros definition for files i/o. 
+*/
+#ifdef _WIN32
+/* seek in file described by its file descriptor fd */
+#define IPATCH_FD_LSEEK(fd, offset,origin) _lseek(fd, offset, origin)
+/* read from file described by its file descriptor fd */
+#define IPATCH_FD_READ(fd, bufdst, count)  _read(fd, bufdst, count)
+/* read to file described by its file descriptor fd */
+#define IPATCH_FD_WRITE(fd, bufsrc, count) _write(fd, bufsrc, count)
+/* close a file described by its file descriptor fd */
+#define IPATCH_FD_CLOSE(fd) _close(fd)
+#else
 #define IPATCH_FD_LSEEK(fd, offset,origin) lseek(fd, offset, origin)
 #define IPATCH_FD_READ(fd, bufdst, count)  read(fd, bufdst, count)
 #define IPATCH_FD_WRITE(fd, bufsrc, count) write(fd, bufsrc, count)
 #define IPATCH_FD_CLOSE(fd) close(fd)
 #endif
-
+   
 #define IPATCH_UNTITLED		_("Untitled")
 
 /* macro for getting a GParamSpec property ID (FIXME - its a private field!) */

--- a/libinstpatch/ipatch_priv.h
+++ b/libinstpatch/ipatch_priv.h
@@ -29,6 +29,22 @@
 #include "misc.h"
 #include "i18n.h"
 
+#if HAVE_IO_H
+#include <io.h> // _lseek(), _close(), _read(), _write() on windows
+#define IPATCH_FD_LSEEK(fd, offset,origin) _lseek(fd, offset, origin)
+#define IPATCH_FD_READ(fd, bufdst, count)  _read(fd, bufdst, count)
+#define IPATCH_FD_WRITE(fd, bufsrc, count) _write(fd, bufsrc, count)
+#define IPATCH_FD_CLOSE(fd) _close(fd)
+#endif
+
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#define IPATCH_FD_LSEEK(fd, offset,origin) lseek(fd, offset, origin)
+#define IPATCH_FD_READ(fd, bufdst, count)  read(fd, bufdst, count)
+#define IPATCH_FD_WRITE(fd, bufsrc, count) write(fd, bufsrc, count)
+#define IPATCH_FD_CLOSE(fd) close(fd)
+#endif
+
 #define IPATCH_UNTITLED		_("Untitled")
 
 /* macro for getting a GParamSpec property ID (FIXME - its a private field!) */


### PR DESCRIPTION
1) Adding checking of Windows headers file `i.o.h` at CMake time.

2) Moving include of O.S headers files in `ipatch_priv.h`.

3)Adding macros for files i/o: `IPATCH_FD_READ(), IPATCH_FD_WRITE(), IPATCH_FD_LSEEK(),
IPATCH_FD_CLOSE()`.
