### PR TITLE
Missing installed include file compat.h

### DIFF
--- a/libinstpatch/CMakeLists.txt
+++ b/libinstpatch/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories (
 
 set ( instpatch_public_HEADERS
     builtin_enums.h
+	compat.h
     IpatchBase.h
     IpatchContainer.h
     IpatchConverter.h


### PR DESCRIPTION
This fix compilation errors when building libswami target.