### PR TITLE
Add getopt support for Windows

### DIFF
--- a/libinstpatch/libinstpatch.def
+++ b/libinstpatch/libinstpatch.def
@@ -1,7 +1,6 @@
 LIBRARY
 EXPORTS
 
-
 _ipatch_code_error
 _ipatch_code_errorv
 _ipatch_convert_DLS2_init
@@ -557,6 +556,7 @@ ipatch_riff_message_detail
 ;ipatch_riff_parser_error_quark
 ;ipatch_riff_parser_get_type
 ;ipatch_riff_parser_new
+ipatch_riff_new
 ipatch_riff_pop_state
 ipatch_riff_push_state
 ipatch_riff_read_chunk

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -9,6 +9,14 @@ include_directories (
     ${SNDFILE_INCLUDE_DIRS}
 )
 
+#adding installed getopt support for Windows 
+if (WIN32)
+    pkg_check_modules ( GETOPT getopt )
+    if(GETOPT_FOUND)
+	    include_directories ( ${GETOPT_INCLUDEDIR} )
+    endif(GETOPT_FOUND)
+endif(WIN32)
+
 link_directories (
     ${GOBJECT_LIBDIR}
     ${GOBJECT_LIBRARY_DIRS}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -12,9 +12,9 @@ include_directories (
 #adding installed getopt support for Windows 
 if ( WIN32 )
     #let the user choosing additionnal search path
-    set (GETOPT_INCLUDE_PATH "d:\\freesw\\include\\getopt" 
+    set (GETOPT_INCLUDE_PATH "" 
         CACHE FILEPATH "Path of getopt.h" )
-    set (CMAKE_REQUIRED_INCLUDES ${GETOPT_INCLUDE_PATH})
+    set (CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${GETOPT_INCLUDE_PATH})
     unset (HAVE_GETOPT_H CACHE)
     check_include_file ( getopt.h HAVE_GETOPT_H )
     if ( HAVE_GETOPT_H )

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -10,12 +10,17 @@ include_directories (
 )
 
 #adding installed getopt support for Windows 
-if (WIN32)
-    pkg_check_modules ( GETOPT getopt )
-    if(GETOPT_FOUND)
-	    include_directories ( ${GETOPT_INCLUDEDIR} )
-    endif(GETOPT_FOUND)
-endif(WIN32)
+if ( WIN32 )
+    #let the user choosing additionnal search path
+	set (GETOPT_INCLUDE_PATH "d:\\freesw\\include\\getopt" 
+	     CACHE FILEPATH "Path of getopt.h" )
+	set (CMAKE_REQUIRED_INCLUDES ${GETOPT_INCLUDE_PATH})
+	unset (HAVE_GETOPT_H CACHE)
+	check_include_file ( getopt.h HAVE_GETOPT_H )
+	if ( HAVE_GETOPT_H )
+		include_directories ( ${CMAKE_REQUIRED_INCLUDES} )
+	endif( HAVE_GETOPT_H )
+endif( WIN32 )
 
 link_directories (
     ${GOBJECT_LIBDIR}

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -12,14 +12,14 @@ include_directories (
 #adding installed getopt support for Windows 
 if ( WIN32 )
     #let the user choosing additionnal search path
-	set (GETOPT_INCLUDE_PATH "d:\\freesw\\include\\getopt" 
-	     CACHE FILEPATH "Path of getopt.h" )
-	set (CMAKE_REQUIRED_INCLUDES ${GETOPT_INCLUDE_PATH})
-	unset (HAVE_GETOPT_H CACHE)
-	check_include_file ( getopt.h HAVE_GETOPT_H )
-	if ( HAVE_GETOPT_H )
-		include_directories ( ${CMAKE_REQUIRED_INCLUDES} )
-	endif( HAVE_GETOPT_H )
+    set (GETOPT_INCLUDE_PATH "d:\\freesw\\include\\getopt" 
+        CACHE FILEPATH "Path of getopt.h" )
+    set (CMAKE_REQUIRED_INCLUDES ${GETOPT_INCLUDE_PATH})
+    unset (HAVE_GETOPT_H CACHE)
+    check_include_file ( getopt.h HAVE_GETOPT_H )
+    if ( HAVE_GETOPT_H )
+        include_directories ( ${CMAKE_REQUIRED_INCLUDES} )
+    endif( HAVE_GETOPT_H )
 endif( WIN32 )
 
 link_directories (

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <libinstpatch/libinstpatch.h>
 
 #define _GNU_SOURCE


### PR DESCRIPTION
This support adds arguments parsing useful for any console application example using libinstpatch library.
Actually riff_dump is one of these executable example that use getopt.