### PR TITLE
GLib parser

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -3,38 +3,28 @@ include_directories (
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
+    ${GLIB_INCLUDEDIR}
+    ${GLIB_INCLUDE_DIRS}
     ${GOBJECT_INCLUDEDIR}
     ${GOBJECT_INCLUDE_DIRS}
     ${SNDFILE_INCLUDEDIR}
     ${SNDFILE_INCLUDE_DIRS}
 )
 
-unset (HAVE_GETOPT_H CACHE)
-check_include_file ( getopt.h HAVE_GETOPT_H )
-
-# adding installed getopt support for Windows 
-if ( WIN32 AND NOT HAVE_GETOPT_H )
-    # let the user choosing additionnal search path
-    set (GETOPT_INCLUDE_PATH "" 
-        CACHE FILEPATH "Path of getopt.h" )
-    set (CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${GETOPT_INCLUDE_PATH})
-    # force check_include_file to see if getopth.h exits in CMAKE_REQUIRED_INCLUDES
-    unset (HAVE_GETOPT_H CACHE)
-    check_include_file ( getopt.h HAVE_GETOPT_H )
-    if ( HAVE_GETOPT_H )
-        include_directories ( ${GETOPT_INCLUDE_PATH} )
-    endif( HAVE_GETOPT_H )
-endif( WIN32 AND NOT HAVE_GETOPT_H )
+if( WIN32 )
+    # disable deprecation warnings 
+    add_definitions ( -D_CRT_SECURE_NO_WARNINGS )
+endif( WIN32 )
 
 link_directories (
+    ${GLIB_LIBDIR}
+    ${GLIB_LIBRARY_DIRS}
     ${GOBJECT_LIBDIR}
     ${GOBJECT_LIBRARY_DIRS}
     ${SNDFILE_LIBDIR}
     ${SNDFILE_LIBRARY_DIRS}
 )
 
-if ( HAVE_GETOPT_H )
-    add_executable ( riff_dump riff_dump.c )
-    add_dependencies( riff_dump libinstpatch )
-    target_link_libraries( riff_dump libinstpatch )
-endif ( HAVE_GETOPT_H )
+add_executable ( riff_dump riff_dump.c )
+add_dependencies( riff_dump libinstpatch )
+target_link_libraries( riff_dump libinstpatch )

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -22,8 +22,6 @@
 #include <string.h>
 #include <libinstpatch/libinstpatch.h>
 
-#define _GNU_SOURCE
-
 static gboolean recurse_riff_chunks (IpatchRiff *riff, char *indent,
 			      GError **err);
 static void display_chunk (IpatchRiff *riff, char *indent);

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -17,9 +17,9 @@
  *   -r, --raw                  Do raw dump rather than formatted hex dump
  *
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+//#include <stdio.h>
+//#include <stdlib.h>
+//#include <string.h>
 #include <libinstpatch/libinstpatch.h>
 
 static gboolean recurse_riff_chunks (IpatchRiff *riff, char *indent,

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -92,7 +92,6 @@ main (int argc, char *argv[])
 	    file_name = *file_arg;
 	}
 
-  g_type_init ();
 	/* libinstpatch initialization */
   ipatch_init ();
 

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -41,7 +41,7 @@ gboolean stop = FALSE;     /* set to TRUE to stop recursion */
 
 int
 main (int argc, char *argv[])
-{   
+{
 	/* riff file variables */
 	char *file_name = NULL; /* file name */
     IpatchFile *riff_file; /* riff file to open */
@@ -51,7 +51,7 @@ main (int argc, char *argv[])
     char indent_buf[256] = ""; /* indentation buffer */
 
     GError *err = NULL;
-    gchar **file_arg = NULL; /* file name argument */
+    static gchar **file_arg = NULL; /* file name argument */
 
 	/* parsing context variables */
     GOptionContext *context = NULL; /* parsing context */
@@ -73,6 +73,8 @@ main (int argc, char *argv[])
     {
         g_print ("option parsing failed: %s\n", err->message);
 		g_error_free (err);
+        g_strfreev (file_arg);
+        g_free(dump_type);
         return (1);
     }
 
@@ -91,8 +93,6 @@ main (int argc, char *argv[])
 	{
 	    file_name = *file_arg;
 	}
-    g_strfreev (file_arg); /* free file arguments array */
-    file_arg = NULL;
 
   g_type_init ();
 	/* libinstpatch initialization */
@@ -105,6 +105,7 @@ main (int argc, char *argv[])
       fprintf (stderr, "Failed to open file '%s': %s\n",
 	       file_name, err ? err->message : "<no details>");
       g_free(dump_type);
+        g_strfreev (file_arg);
       return (1);
     }
 
@@ -116,6 +117,7 @@ main (int argc, char *argv[])
       fprintf (stderr, "Failed to start RIFF parse of file '%s': %s\n",
 	       file_name, err ? err->message : "<no details>");
       g_free(dump_type);
+        g_strfreev (file_arg);
       return (1);
     }
 
@@ -137,8 +139,12 @@ main (int argc, char *argv[])
       fprintf (stderr, "%s\n", ipatch_riff_message_detail
 	       (riff, -1, "Error while parsing RIFF file '%s': %s",
 		file_name, err ? err->message : "<no details>"));
+        g_strfreev (file_arg);
       return (1);
     }
+
+  g_strfreev (file_arg); /* free file arguments array */
+  file_arg = NULL;
 
   return (0);
 }

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -124,8 +124,8 @@ main (int argc, char *argv[])
       || (dump_type && strncmp (dump_type, chunk->idstr, 4) == 0))
     display = TRUE;
 
-  g_free(dump_type);
-  dump_type = NULL;
+//  g_free(dump_type);
+//  dump_type = NULL;
 
   if (display) display_chunk (riff, indent_buf);
   chunk_index++;
@@ -137,12 +137,15 @@ main (int argc, char *argv[])
       fprintf (stderr, "%s\n", ipatch_riff_message_detail
 	       (riff, -1, "Error while parsing RIFF file '%s': %s",
 		file_name, err ? err->message : "<no details>"));
+        g_free(dump_type);
         g_strfreev (file_arg);
       return (1);
     }
 
+  g_free(dump_type); /* free dump type */
+  dump_type = NULL;  /* not needed but a good practice */
   g_strfreev (file_arg); /* free file arguments array */
-  file_arg = NULL;
+  file_arg = NULL;   /* not needed but a good practice */
 
   return (0);
 }

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -3,8 +3,19 @@
  *
  * riff_dump utility (licensed separately from libInstPatch)
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
- *
  * Public Domain, use as you please.
+ *
+ * Usage:
+ *  riff_dump [OPTION] file.sf2
+ *
+ * Help options:
+ *   -h, --help                 Display help options
+ *
+ * Application options :
+ *   -d, --dump=CHUNK_INDEX     Dump a chunk by CHUNK_INDEX index
+ *   -t, --dump-type=CHNK       Dump a chunk by RIFF FOURCC CHNK
+ *   -r, --raw                  Do raw dump rather than formatted hex dump
+ *
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,221 +23,213 @@
 #include <libinstpatch/libinstpatch.h>
 
 #define _GNU_SOURCE
-#include <getopt.h>
 
-void usage (void);
 gboolean recurse_riff_chunks (IpatchRiff *riff, char *indent,
 			      GError **err);
 void display_chunk (IpatchRiff *riff, char *indent);
 gboolean dump_chunk (IpatchRiff *riff, GError **err);
 
-/* chunk index - so commands can be run on specific chunks */
-int chunk_index = 0;
-int dump_index = -1;	 /* set to chunk index if chunk dump requested */
-char *dump_type = NULL;	/* set to 4 char string if dumping a chunk type */
-gboolean raw_dump = FALSE;	/* set to TRUE for raw byte dumps */
-gboolean display = TRUE;      /* set to FALSE to not display chunks */
-gboolean stop = FALSE;		/* set to TRUE to stop recursion */
+/* options arguments (global for convenience)*/
+gint dump_index = -1;      /* set to chunk index if chunk dump requested */
+gchar *dump_type = NULL;   /* set to 4 char string if dumping a chunk type */
+gboolean raw_dump = FALSE; /* set to TRUE for raw byte dumps */
+gchar **file_arg = NULL; /* file name argument */
 
-extern char *optarg;
-extern int optind, opterr, optopt;
+/* dislaying variables (global for convenience)*/
+int chunk_index = 0;       /* current index */
+gboolean display = TRUE;   /* set to FALSE to not display chunks */
+gboolean stop = FALSE;     /* set to TRUE to stop recursion */
 
 int
 main (int argc, char *argv[])
-{
-  IpatchRiff *riff;
-  IpatchRiffChunk *chunk;
-  IpatchFile *file;
-  IpatchFileHandle *fhandle;
-  char indent_buf[256] = "";
-  GError *err = NULL;
-  char *file_name = NULL;
-  int option_index = 0;
-  int c;
+{   
+	/* riff file variables */
+	char *file_name = NULL; /* file name */
+    IpatchFile *riff_file; /* riff file to open */
+    IpatchFileHandle *fhandle = NULL; /* riff file file handle */
+    IpatchRiff *riff;
+    IpatchRiffChunk *chunk;
+    char indent_buf[256] = ""; /* indentation buffer */
 
-  static struct option long_options[] =
+    GError *err = NULL;
+
+	/* parsing context variables */
+    GOptionContext *context = NULL; /* parsing context */
+	
+	/* option entries to parse */
+	static GOptionEntry entries[] =
     {
-      {"dump", 1, 0, 'd'},
-      {"dump-type", 1, 0, 't'},
-      {"raw", 0, 0, 'r'},
-      {NULL, 0, NULL, 0}
+        { "dump", 'd', 0, G_OPTION_ARG_INT, &dump_index, "Dump a chunk by CHUNK_INDEX index", "CHUNK_INDEX" },
+        { "dump-type", 't', 0, G_OPTION_ARG_STRING, &dump_type, "Dump a chunk by RIFF FOURCC CHNK", "CHNK" },
+        { "raw", 'r', 0, G_OPTION_ARG_NONE, &raw_dump, "Do raw dump rather than formatted hex dump", NULL },
+        { G_OPTION_REMAINING, '\0', 0, G_OPTION_ARG_FILENAME_ARRAY, &file_arg, NULL, "file.sf2" },
+        { NULL }
     };
-
-  while (TRUE)
+ 
+	/* parse option in command line */
+    context = g_option_context_new (NULL);
+    g_option_context_add_main_entries (context, entries, NULL);
+    if (!g_option_context_parse (context, &argc, &argv, &err))
     {
-      c = getopt_long (argc, argv, "rd:t:", long_options, &option_index);
-      if (c == -1) break;
+        g_print ("option parsing failed: %s\n", err->message);
+		g_error_free (err);
+        return (1);
+    }
 
-      switch (c)
+	/* prepare variable for displaying */
+    if (dump_index >=0)
+    {
+        display = FALSE;  /* we enable display when we find chunk */
+    }
+    else if (dump_type)
+    {
+        display = FALSE;
+    }
+
+	/* take the file name argument */
+  	if(file_arg)
 	{
-	case 'd':		/* dump chunk? */
-	  dump_index = atoi (optarg); /* get chunk index */
-	  display = FALSE;  /* we enable display when we find chunk */
-	  break;
-	case 't':
-	  dump_type = g_strndup (optarg, 4);
-	  display = FALSE;
-	  break;
-	case 'r':
-	  raw_dump = TRUE;
-	  break;
-	case ':':		/* missing option */
-	  fprintf (stderr, "Missing parameter for option '-%c, %s'\n",
-		   (char)(long_options[option_index].val),
-		   long_options[option_index].name);
-	  usage();
-	  exit (1);
-	  break;
-	case '?':		/* unknown switch */
-	  usage();
-	  exit(1);
-	  break;
-	default:
-	  fprintf (stderr, "Unknown getopt return val '%d'\n", c);
-	  exit (1);
-	  break;
+	    file_name = *file_arg;
 	}
-    }
 
-  if (optind >= argc)
+	/* libinstpatch initialization */
+    ipatch_init ();
+
+    /* try to open riff_file */
+	riff_file = ipatch_file_new ();
+	if(file_name) fhandle = ipatch_file_open (riff_file, file_name, "r", &err);
+    if (!(fhandle))
     {
-      usage ();
-      exit (1);
+        fprintf (stderr, "Failed to open file '%s': %s\n",
+	            file_name, err ? err->message : "<no details>");
+        g_free(dump_type);
+		g_strfreev (file_arg); /* free file arguments array */
+        return (1);
     }
+	g_strfreev (file_arg); /* free array */
 
-  file_name = argv[optind];
 
-  g_type_init ();
-  ipatch_init ();
+    riff = ipatch_riff_new (fhandle);
 
-  file = ipatch_file_new ();
-  if (!(fhandle = ipatch_file_open (file, file_name, "r", &err)))
+	/* start reading chunk */
+    if (!(chunk = ipatch_riff_start_read (riff, &err)))
     {
-      fprintf (stderr, "Failed to open file '%s': %s\n",
-	       file_name, err ? err->message : "<no details>");
-      exit (1);
+        fprintf (stderr, "Failed to start RIFF parse of file '%s': %s\n",
+	             file_name, err ? err->message : "<no details>");
+        g_free(dump_type);
+        return (1);
     }
 
-  riff = ipatch_riff_new (fhandle);
-
-  if (!(chunk = ipatch_riff_start_read (riff, &err)))
-    {
-      fprintf (stderr, "Failed to start RIFF parse of file '%s': %s\n",
-	       file_name, err ? err->message : "<no details>");
-      exit (1);
-    }
-
-  /* if a dump of chunk 0 requested or type matches, display everything */
-  if (dump_index == 0
+	/* if a dump of chunk 0 requested or type matches, display everything */
+    if ( (dump_index == 0)
       || (dump_type && strncmp (dump_type, chunk->idstr, 4) == 0))
-    display = TRUE;
-
-  if (display) display_chunk (riff, indent_buf);
-  chunk_index++;
-  strcat (indent_buf, "  ");
-
-  if (!recurse_riff_chunks (riff, indent_buf, &err))
     {
-      fprintf (stderr, "%s\n", ipatch_riff_message_detail
-	       (riff, -1, "Error while parsing RIFF file '%s': %s",
-		file_name, err ? err->message : "<no details>"));
-      exit (1);
+      display = TRUE;
     }
 
-  exit (0);
-}
+	if (display)
+    {
+        display_chunk (riff, indent_buf);
+	}
+    chunk_index++;
+    strcat (indent_buf, "  ");
 
-void
-usage (void)
-{
-  fprintf (stderr, "Usage: riff_dump [OPTION]... FILE\n");
-  fprintf (stderr, "  -d, --dump=CHUNK_INDEX       "
-	   "Dump a chunk by index\n");
-  fprintf (stderr, "  -t, --dump-type='CHNK'       "
-	   "Dump a chunk by RIFF FOURCC ID\n");
-  fprintf (stderr, "  -r, --raw                    "
-	   "Do raw dump rather than formatted hex dump\n\n");
-  fprintf (stderr, "CHUNK_INDEX - The chunk index (number in brackets [])\n");
+	/* continue to read by recursion */
+    if (!recurse_riff_chunks (riff, indent_buf, &err))
+    {
+        fprintf (stderr, "%s\n", ipatch_riff_message_detail
+	            (riff, -1, "Error while parsing RIFF file '%s': %s",
+		         file_name, err ? err->message : "<no details>"));
+        g_free(dump_type);
+        return (1);
+    }
+	g_free(dump_type);
+
+    return (0);
 }
 
 gboolean
 recurse_riff_chunks (IpatchRiff *riff, char *indent, GError **err)
 {
-  IpatchRiffChunk *chunk;
-  gboolean retval;
+    IpatchRiffChunk *chunk;
+    gboolean retval;
 
-  while (!stop && (chunk = ipatch_riff_read_chunk (riff, err)))
+    while (!stop && (chunk = ipatch_riff_read_chunk (riff, err)))
     {
-      if (dump_index == chunk_index) /* dump by chunk index match? */
-	{
-	  if (chunk->type != IPATCH_RIFF_CHUNK_SUB) /* list chunk? */
-	    {
-	      display_chunk (riff, indent);
+        if (dump_index == chunk_index) /* dump by chunk index match? */
+        {
+            if (chunk->type != IPATCH_RIFF_CHUNK_SUB) /* list chunk? */
+            {
+                display_chunk (riff, indent);
 
-	      strcat (indent, "  ");
-	      display = TRUE;
-	      retval = recurse_riff_chunks (riff, indent, err);
+                strcat (indent, "  ");
+                display = TRUE;
+                retval = recurse_riff_chunks (riff, indent, err);
 
-	      stop = TRUE;
-	      return (retval);
-	    }
-	  else
-	    {
-	      retval = dump_chunk (riff, err); /* hex dump of sub chunk */
-	      stop = TRUE;
-	      return (retval);
-	    }
-	} /* dump by type match? */
-      else if (dump_type && strncmp (dump_type, chunk->idstr, 4) == 0)
-	{
-	  if (chunk->type != IPATCH_RIFF_CHUNK_SUB) /* list chunk? */
-	    {
-	      display = TRUE;
-	      strcat (indent, "  ");
-	      recurse_riff_chunks (riff, indent, err);
-	      indent[strlen (indent) - 2] = '\0';
-	      display = FALSE;
-	    }
-	  else dump_chunk (riff, err); /* hex dump of sub chunk */
-	}
-      else			/* no dump match, just do stuff */
-	{
-	  if (display) display_chunk (riff, indent);
-	  chunk_index++;		/* advance chunk index */
+                stop = TRUE;
+                return (retval);
+            }
+            else
+            {
+                retval = dump_chunk (riff, err); /* hex dump of sub chunk */
+                stop = TRUE;
+                return (retval);
+            }
+        } /* dump by type match? */
+        else if (dump_type && strncmp (dump_type, chunk->idstr, 4) == 0)
+        {
+            if (chunk->type != IPATCH_RIFF_CHUNK_SUB) /* list chunk? */
+            {
+                display = TRUE;
+                strcat (indent, "  ");
+                recurse_riff_chunks (riff, indent, err);
+                indent[strlen (indent) - 2] = '\0';
+                display = FALSE;
+            }
+            else dump_chunk (riff, err); /* hex dump of sub chunk */
+        }
+        else /* no dump match, just do stuff */
+        {
+            if (display) display_chunk (riff, indent);
+            chunk_index++;		/* advance chunk index */
 
-	  if (chunk->type != IPATCH_RIFF_CHUNK_SUB)	/* list chunk? */
-	    {
-	      strcat (indent, "  ");
-	      if (!recurse_riff_chunks (riff, indent, err)) return (FALSE);
-	      indent[strlen (indent) - 2] = '\0';
-	    }
-	}
+            if (chunk->type != IPATCH_RIFF_CHUNK_SUB)	/* list chunk? */
+            {
+                strcat (indent, "  ");
+                if (!recurse_riff_chunks (riff, indent, err)) return (FALSE);
+                indent[strlen (indent) - 2] = '\0';
+            }
+        }
 
-      if (!ipatch_riff_close_chunk (riff, -1, err)) return (FALSE);
+        if (!ipatch_riff_close_chunk (riff, -1, err)) return (FALSE);
     }
 
-  return (ipatch_riff_get_error (riff, NULL));
+    return (ipatch_riff_get_error (riff, NULL));
 }
 
 void
 display_chunk (IpatchRiff *riff, char *indent)
 {
-  IpatchRiffChunk *chunk;
-  int filepos;
+    IpatchRiffChunk *chunk;
+    int filepos;
 
-  chunk = ipatch_riff_get_chunk (riff, -1);
-  filepos = ipatch_riff_get_position (riff);
+    chunk = ipatch_riff_get_chunk (riff, -1);
+    filepos = ipatch_riff_get_position (riff);
 
-  if (chunk->type == IPATCH_RIFF_CHUNK_SUB)
-    printf ("%s(%.4s)[%4d] (ofs = 0x%x, size = %d)\n", indent,
-	    chunk->idstr, chunk_index,
-	    filepos - (chunk->position + IPATCH_RIFF_HEADER_SIZE),
-	    chunk->size);
-  else	/* list chunk */
-    printf ("%s<%.4s>[%4d] (ofs = 0x%x, size = %d)\n", indent,
-	    chunk->idstr, chunk_index,
-	    filepos - (chunk->position + IPATCH_RIFF_HEADER_SIZE),
-	    chunk->size);
+    if (chunk->type == IPATCH_RIFF_CHUNK_SUB)
+	{
+        printf ("%s(%.4s)[%4d] (ofs = 0x%x, size = %d)\n", indent,
+                chunk->idstr, chunk_index,
+                filepos - (chunk->position + IPATCH_RIFF_HEADER_SIZE),
+                chunk->size);
+	}
+	else	/* list chunk */
+    {
+		printf ("%s<%.4s>[%4d] (ofs = 0x%x, size = %d)\n", indent,
+                chunk->idstr, chunk_index,
+                filepos - (chunk->position + IPATCH_RIFF_HEADER_SIZE),
+                chunk->size);
+	}
 }
 
 #define BUFFER_SIZE (16 * 1024)
@@ -235,53 +238,54 @@ display_chunk (IpatchRiff *riff, char *indent)
 gboolean
 dump_chunk (IpatchRiff *riff, GError **err)
 {
-  IpatchRiffChunk *chunk;
-  guint8 buf[BUFFER_SIZE];
-  int filepos, read_size, bytes_left, i;
+    IpatchRiffChunk *chunk;
+    guint8 buf[BUFFER_SIZE];
+    int filepos, read_size, bytes_left, i;
 
-  chunk = ipatch_riff_get_chunk (riff, -1);
-  filepos = ipatch_riff_get_position (riff);
+    chunk = ipatch_riff_get_chunk (riff, -1);
+    filepos = ipatch_riff_get_position (riff);
 
-  if (!raw_dump)
+    if (!raw_dump)
     {
-      printf ("Dump chunk: (%.4s)[%4d] (ofs = 0x%x, size = %d)",
-	      chunk->idstr, chunk_index,
-	      filepos - (chunk->position + IPATCH_RIFF_HEADER_SIZE),
-	      chunk->size);
+        printf ("Dump chunk: (%.4s)[%4d] (ofs = 0x%x, size = %d)",
+                chunk->idstr, chunk_index,
+                filepos - (chunk->position + IPATCH_RIFF_HEADER_SIZE),
+	            chunk->size);
 
-      i = filepos & ~0xF;   /* round down to nearest 16 byte offset */
-      while (i < filepos) /* advance to start point in 16 byte block */
-	{
-	  if (!(i & 0xF)) printf ("\n%08u  ", i); /* print file position */
-	  else if (!(i & 0x3)) printf (" |  "); /* print divider */
-	  printf ("   ");		/* skip 1 byte character */
-	  i++;
-	}
+        i = filepos & ~0xF;   /* round down to nearest 16 byte offset */
+        while (i < filepos) /* advance to start point in 16 byte block */
+        {
+            if (!(i & 0xF)) printf ("\n%08u  ", i); /* print file position */
+            else if (!(i & 0x3)) printf (" |  "); /* print divider */
+            printf ("   ");		/* skip 1 byte character */
+            i++;
+        }
     }
 
-  read_size = BUFFER_SIZE;
-  bytes_left = chunk->size;
-  while (bytes_left)		/* loop until chunk exhausted */
+    read_size = BUFFER_SIZE;
+    bytes_left = chunk->size;
+    while (bytes_left)		/* loop until chunk exhausted */
     {
-      if (bytes_left < BUFFER_SIZE) read_size = bytes_left;
-      if (!ipatch_file_read (riff->handle, &buf, read_size, err))
-	return (FALSE);
+        if (bytes_left < BUFFER_SIZE) read_size = bytes_left;
+        if (!ipatch_file_read (riff->handle, &buf, read_size, err))
+        return (FALSE);
 
-      for (i = 0; i < read_size; i++, filepos++)
-	{
-	  if (!raw_dump)
-	    {
-	      if (!(filepos & 0xF))
-		printf ("\n%08u  ", filepos); /* print file position */
-	      else if (!(filepos & 0x3)) printf (" |  "); /* print divider */
-	    }
+        for (i = 0; i < read_size; i++, filepos++)
+        {
+            if (!raw_dump)
+            {
+                if (!(filepos & 0xF))
+                    printf ("\n%08u  ", filepos); /* print file position */
+                else if (!(filepos & 0x3)) 
+                    printf (" |  "); /* print divider */
+            }
 
-	  printf ("%02X ", buf[i]);
-	}
-      bytes_left -= read_size;
+            printf ("%02X ", buf[i]);
+        }
+        bytes_left -= read_size;
     }
 
-  printf ("\n");
+    printf ("\n");
 
-  return (TRUE);
+    return (TRUE);
 }

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -17,9 +17,7 @@
  *   -r, --raw                  Do raw dump rather than formatted hex dump
  *
  */
-//#include <stdio.h>
-//#include <stdlib.h>
-//#include <string.h>
+#include <string.h>
 #include <libinstpatch/libinstpatch.h>
 
 static gboolean recurse_riff_chunks (IpatchRiff *riff, char *indent,

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -24,20 +24,20 @@
 
 #define _GNU_SOURCE
 
-gboolean recurse_riff_chunks (IpatchRiff *riff, char *indent,
+static gboolean recurse_riff_chunks (IpatchRiff *riff, char *indent,
 			      GError **err);
-void display_chunk (IpatchRiff *riff, char *indent);
-gboolean dump_chunk (IpatchRiff *riff, GError **err);
+static void display_chunk (IpatchRiff *riff, char *indent);
+static gboolean dump_chunk (IpatchRiff *riff, GError **err);
 
 /* options arguments (global for convenience)*/
-gint dump_index = -1;      /* set to chunk index if chunk dump requested */
-gchar *dump_type = NULL;   /* set to 4 char string if dumping a chunk type */
-gboolean raw_dump = FALSE; /* set to TRUE for raw byte dumps */
+static gint dump_index = -1;      /* set to chunk index if chunk dump requested */
+static gchar *dump_type = NULL;   /* set to 4 char string if dumping a chunk type */
+static gboolean raw_dump = FALSE; /* set to TRUE for raw byte dumps */
 
 /* dislaying variables (global for convenience)*/
-int chunk_index = 0;       /* current index */
-gboolean display = TRUE;   /* set to FALSE to not display chunks */
-gboolean stop = FALSE;     /* set to TRUE to stop recursion */
+static int chunk_index = 0;       /* current index */
+static gboolean display = TRUE;   /* set to FALSE to not display chunks */
+static gboolean stop = FALSE;     /* set to TRUE to stop recursion */
 
 int
 main (int argc, char *argv[])

--- a/utils/riff_dump.c
+++ b/utils/riff_dump.c
@@ -124,9 +124,6 @@ main (int argc, char *argv[])
       || (dump_type && strncmp (dump_type, chunk->idstr, 4) == 0))
     display = TRUE;
 
-//  g_free(dump_type);
-//  dump_type = NULL;
-
   if (display) display_chunk (riff, indent_buf);
   chunk_index++;
   strcat (indent_buf, "  ");


### PR DESCRIPTION
This PR replace PR https://github.com/swami/libinstpatch/pull/23 which must be ignored.

Getopt support is removed from CMakeLists.txt. 
riff_dump command line executable makes use of Glib options parser instead of getopt.  
This fix #19.