### PR TITLE
 Bug in IpatchSF2GenSampleModes enum.

### DIFF
--- a/libinstpatch/IpatchSF2Gen.h
+++ b/libinstpatch/IpatchSF2Gen.h
@@ -164,12 +164,19 @@ typedef enum
     IPATCH_SF2_GEN_ROOT_NOTE_OVERRIDE = 58	/* root note override */
 } IpatchSF2GenType;
 
-/* Flags for IPATCH_SF2_GEN_SAMPLE_MODES generator */
+/* Flags for IPATCH_SF2_GEN_SAMPLE_MODES generator
+   sfspec24.pdf - p 36 - generator sampleModes (54)
+*/
 typedef enum
 {
-    IPATCH_SF2_GEN_SAMPLE_MODE_NOLOOP = 0,
-    IPATCH_SF2_GEN_SAMPLE_MODE_LOOP   = 1 << 0,
-    IPATCH_SF2_GEN_SAMPLE_MODE_LOOP_RELEASE = 1 << 1
+  IPATCH_SF2_GEN_SAMPLE_MODE_NOLOOP, /* no loop */
+  IPATCH_SF2_GEN_SAMPLE_MODE_LOOP,   /* standard loop */
+  /* not used. Should be interpreted as "no loop" */
+  IPATCH_SF2_GEN_SAMPLE_MODE_UNUSED,
+  /* loop during the depression of the key, then plays the remainder
+     of the sample.
+  */
+  IPATCH_SF2_GEN_SAMPLE_MODE_LOOP_RELEASE
 } IpatchSF2GenSampleModes;
 
 /* generator info and constraints structure */

--- a/libinstpatch/IpatchSF2IZone.c
+++ b/libinstpatch/IpatchSF2IZone.c
@@ -477,6 +477,11 @@ ipatch_sf2_izone_get_property(GObject *object, guint property_id,
             {
                 val = IPATCH_SAMPLE_LOOP_NONE;
             }
+            /* not used. Should be interpreted as "no loop" */
+            else if(amt.uword == IPATCH_SF2_GEN_SAMPLE_MODE_UNUSED)
+            {
+                val = IPATCH_SAMPLE_LOOP_NONE;
+            }
             else if(amt.uword == IPATCH_SF2_GEN_SAMPLE_MODE_LOOP_RELEASE)
             {
                 val = IPATCH_SAMPLE_LOOP_RELEASE;


### PR DESCRIPTION
This PR fixes issue https://github.com/swami/swami/issues/12

 - IPATCH_SF2_GEN_SAMPLE_MODE_LOOP_RELEASE value that must be 3 (instead of 2).
 - Also, enum IPATCH_SF2_GEN_SAMPLE_MODE_LOOP_RELEASE value must be added
   (set to 2) because it should be interpreted as "loop none".

   (sfspec24.pdf - p 36 - generator sampleModes (54)).

