### PR TITLE
Changed argument in ipatch_file_buf_memset to uchar

### DIFF
--- a/libinstpatch/IpatchFile.h
+++ b/libinstpatch/IpatchFile.h
@@ -232,7 +232,7 @@ void ipatch_file_buf_write(IpatchFileHandle *handle, gconstpointer buf,
                            guint size);
 #define ipatch_file_buf_zero(filebuf, size) \
   ipatch_file_buf_memset(filebuf, 0, size)
-void ipatch_file_buf_memset(IpatchFileHandle *handle, char c, guint size);
+void ipatch_file_buf_memset(IpatchFileHandle *handle, unsigned char c, guint size);
 void ipatch_file_buf_set_size(IpatchFileHandle *handle, guint size);
 gboolean ipatch_file_buf_commit(IpatchFileHandle *handle, GError **err);
 #define ipatch_file_buf_skip(filebuf, offset) \

--- a/libinstpatch/IpatchFileBuf.c
+++ b/libinstpatch/IpatchFileBuf.c
@@ -496,7 +496,7 @@ ipatch_file_buf_write(IpatchFileHandle *handle, gconstpointer buf, guint size)
  * current position.  Buffer is expanded if necessary.
  */
 void
-ipatch_file_buf_memset(IpatchFileHandle *handle, char c, guint size)
+ipatch_file_buf_memset(IpatchFileHandle *handle, unsigned char c, guint size)
 {
     g_return_if_fail(handle != NULL);
 


### PR DESCRIPTION
to fix an overflow in implicit constant conversion.