### PR TITLE
Inconsistent licensing in file headers

### DIFF
--- a/libinstpatch/IpatchState.c
+++ b/libinstpatch/IpatchState.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchState.h
+++ b/libinstpatch/IpatchState.h
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchStateGroup.c
+++ b/libinstpatch/IpatchStateGroup.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchStateGroup.h
+++ b/libinstpatch/IpatchStateGroup.h
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchStateItem.c
+++ b/libinstpatch/IpatchStateItem.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchStateItem.h
+++ b/libinstpatch/IpatchStateItem.h
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchState_types.c
+++ b/libinstpatch/IpatchState_types.c
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/IpatchState_types.h
+++ b/libinstpatch/IpatchState_types.h
@@ -5,7 +5,7 @@
  * Copyright (C) 1999-2014 Element Green <element@elementsofsound.org>
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
+ * modify it under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation; version 2.1
  * of the License only.
  *

--- a/libinstpatch/libinstpatch.h.in
+++ b/libinstpatch/libinstpatch.h.in
@@ -12,12 +12,12 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA or point your web browser to http://www.gnu.org.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA or on the web at http://www.gnu.org.
  */
 #ifndef __LIB_INST_PATCH_H__
 #define __LIB_INST_PATCH_H__

--- a/libinstpatch/version.h.in
+++ b/libinstpatch/version.h.in
@@ -12,12 +12,12 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA or point your web browser to http://www.gnu.org.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA or on the web at http://www.gnu.org.
  */
 #ifndef __IPATCH_VERSION_H__
 #define __IPATCH_VERSION_H__

--- a/tests/sample_list_test.c
+++ b/tests/sample_list_test.c
@@ -22,12 +22,12 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA or point your web browser to http://www.gnu.org.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA or on the web at http://www.gnu.org.
  */
 #include <libinstpatch/libinstpatch.h>
 #include <math.h>

--- a/tests/sample_test.c
+++ b/tests/sample_test.c
@@ -18,12 +18,12 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
+ * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA
- * 02111-1307, USA or point your web browser to http://www.gnu.org.
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA or on the web at http://www.gnu.org.
  */
 #include <libinstpatch/libinstpatch.h>
 


### PR DESCRIPTION
Some of the file headers incorrectly state a GPL license. From my understanding, all source code under `libinstpatch/` should be LGPL licensed. This PR consistently changes to license to LGPL.

@Element-Green @elementgreen Acknowledge please.