### PR TITLE
Fix variable used but not initialized.

### DIFF
--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -216,8 +216,7 @@ ipatch_convert_object_to_type_multi(GObject *object, GType type, GError **err)
 GList *
 ipatch_convert_object_to_type_multi_list(GObject *object, GType type, GError **err)
 {
-    va_list empty;
-    return (ipatch_convert_object_to_type_multi_set_vlist(object, type, err, NULL, empty));
+    return (ipatch_convert_object_to_type_multi_set_vlist(object, type, err, NULL, NULL));
 }
 
 /**
@@ -295,7 +294,8 @@ ipatch_convert_object_to_type_multi_set_vlist(GObject *object, GType type, GErro
         return NULL;
     }
 
-    if(first_property_name)
+    /* assign properties (if any) */
+	if(first_property_name)
     {
         g_object_set_valist((GObject *)conv, first_property_name, args);
     }

--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -216,7 +216,7 @@ ipatch_convert_object_to_type_multi(GObject *object, GType type, GError **err)
 GList *
 ipatch_convert_object_to_type_multi_list(GObject *object, GType type, GError **err)
 {
-    /* Note: empty is intentionally not initialized. It allows to fix some on ARM and PPC.
+    /* Note: empty is intentionally not initialized. It allows to fix some build on ARM and PPC.
        It is save to use, because empty is not accessed in ipatch_convert_object_to_type_multi_set_vlist
        when the second last argument is NULL.
     */

--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -216,7 +216,12 @@ ipatch_convert_object_to_type_multi(GObject *object, GType type, GError **err)
 GList *
 ipatch_convert_object_to_type_multi_list(GObject *object, GType type, GError **err)
 {
-    return (ipatch_convert_object_to_type_multi_set_vlist(object, type, err, NULL, NULL));
+    /* Note: empty is intentionally not initialized. It allows to fix some on ARM and PPC.
+       It is save to use, because empty is not accessed in ipatch_convert_object_to_type_multi_set_vlist
+       when the second last argument is NULL.
+    */
+    va_list empty;
+    return (ipatch_convert_object_to_type_multi_set_vlist(object, type, err, NULL, empty));
 }
 
 /**

--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -295,7 +295,7 @@ ipatch_convert_object_to_type_multi_set_vlist(GObject *object, GType type, GErro
     }
 
     /* assign properties (if any) */
-	if(first_property_name)
+    if(first_property_name)
     {
         g_object_set_valist((GObject *)conv, first_property_name, args);
     }


### PR DESCRIPTION
The variable `empty `being a function parameter, this PR fix a potential violation access.

Note: this was discovered by a compiler warning.