### PR TITLE
Add deinitialization function ipatch_deinit()

### DIFF
--- a/libinstpatch/IpatchContainer.c
+++ b/libinstpatch/IpatchContainer.c
@@ -68,8 +68,6 @@ ipatch_container_get_type(void)
 
         item_type = g_type_register_static(IPATCH_TYPE_ITEM, "IpatchContainer",
                                            &item_info, G_TYPE_FLAG_ABSTRACT);
-
-        _ipatch_container_notify_init();  /* init container add/remove notify system */
     }
 
     return (item_type);

--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -52,7 +52,8 @@ typedef struct _LogEntry
 } LogEntry;
 
 
-static void _ipatch_converter_free_converter_info(IpatchConverterInfo *data);
+static void _ipatch_converter_free_converter_info(IpatchConverterInfo *data,
+                                                  gpointer user_data);
 static gint priority_GCompareFunc(gconstpointer a, gconstpointer b);
 static const IpatchConverterInfo *convert_lookup_map_U(GType **array, GType conv_type,
         GType src_type, GType dest_type, guint flags);
@@ -81,12 +82,14 @@ void _ipatch_converter_init(void)
 void _ipatch_converter_deinit(void)
 {
     /* free list of all registered IpatchConverterInfo */
-    g_list_free_full(conv_maps,
-                     (GDestroyNotify)_ipatch_converter_free_converter_info);
+    g_list_foreach(conv_maps,
+                   (GFunc)_ipatch_converter_free_converter_info, NULL);
+    g_list_free(conv_maps);
 }
 
 /* free one conv_maps data */
-static void _ipatch_converter_free_converter_info(IpatchConverterInfo *data)
+static void _ipatch_converter_free_converter_info(IpatchConverterInfo *data,
+                                                  gpointer user_data)
 {
     g_slice_free(IpatchConverterInfo,data);
 }

--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -52,6 +52,7 @@ typedef struct _LogEntry
 } LogEntry;
 
 
+static void _ipatch_converter_free_converter_info(IpatchConverterInfo *data);
 static gint priority_GCompareFunc(gconstpointer a, gconstpointer b);
 static const IpatchConverterInfo *convert_lookup_map_U(GType **array, GType conv_type,
         GType src_type, GType dest_type, guint flags);
@@ -68,7 +69,29 @@ G_LOCK_DEFINE_STATIC(conv_maps);
 static GList *conv_maps = NULL;	/* list of all registered IpatchConverterInfo */
 static gpointer parent_class = NULL;
 
+/*------ Initialization/deinitialization of converter system ----------------*/
+/* Initialize converter system (conv_maps static list) */
+void _ipatch_converter_init(void)
+{
+    /* list of all registered IpatchConverterInfo */
+    conv_maps = NULL;
+}
 
+/* Free converter system */
+void _ipatch_converter_deinit(void)
+{
+    /* free list of all registered IpatchConverterInfo */
+    g_list_free_full(conv_maps,
+                     (GDestroyNotify)_ipatch_converter_free_converter_info);
+}
+
+/* free one conv_maps data */
+static void _ipatch_converter_free_converter_info(IpatchConverterInfo *data)
+{
+    g_slice_free(IpatchConverterInfo,data);
+}
+
+/*------ Converter system API ----------------------------------------------*/
 /**
  * ipatch_convert_objects:
  * @input: Input object

--- a/libinstpatch/IpatchDLS2Info.c
+++ b/libinstpatch/IpatchDLS2Info.c
@@ -42,6 +42,8 @@ typedef struct
     GHashTable *prop_hash;
 } HashListBag;
 
+static void _ipatch_DLS2_infos_free_infos(HashListBag *bag);
+
 static void install_prop_helper(GObjectClass *obj_class, guint property_id,
                                 GParamSpec *pspec, GHashTable *hash);
 
@@ -49,6 +51,28 @@ static void install_prop_helper(GObjectClass *obj_class, guint property_id,
    property notifies */
 static GSList *info_hash_list = NULL;
 
+/* ----- Initialization/deinitialization of DLS storing infos  structure ----*/
+/* Initialize list */
+void _ipatch_DLS2_infos_init(void)
+{
+    info_hash_list = NULL;
+}
+
+/* Free list */
+void _ipatch_DLS2_infos_deinit()
+{
+    g_slist_free_full(info_hash_list,
+                     (GDestroyNotify)_ipatch_DLS2_infos_free_infos);
+}
+
+/* Free list data */
+static void _ipatch_DLS2_infos_free_infos(HashListBag *bag)
+{
+    g_hash_table_destroy(bag->prop_hash);
+    g_free(bag);
+}
+
+/* ----- API for DLS storing infos  structure -------------------------------*/
 
 /**
  * ipatch_dls2_info_get:

--- a/libinstpatch/IpatchDLS2Sample.c
+++ b/libinstpatch/IpatchDLS2Sample.c
@@ -102,6 +102,19 @@ G_DEFINE_TYPE_WITH_CODE(IpatchDLS2Sample, ipatch_dls2_sample,
                         G_IMPLEMENT_INTERFACE(IPATCH_TYPE_SAMPLE,
                                 ipatch_dls2_sample_iface_init))
 
+/* ----- Initialization/deinitialization of ClassPropBag list ---------------*/
+void _ipatch_DLS2_sample_init(void)
+{
+    info_pspec_list = NULL;
+}
+
+void _ipatch_DLS2_sample_deinit()
+{
+    g_slist_free_full(info_pspec_list, g_free);
+}
+
+/* ----- IpatchDSL2SAmple object functions  ---------------------------------*/
+
 /* sample interface initialization */
 static void
 ipatch_dls2_sample_iface_init(IpatchSampleIface *sample_iface)

--- a/libinstpatch/IpatchFile.c
+++ b/libinstpatch/IpatchFile.c
@@ -111,6 +111,23 @@ G_DEFINE_TYPE(IpatchFile, ipatch_file, IPATCH_TYPE_ITEM);
 G_LOCK_DEFINE_STATIC(ipatch_file_pool);
 static GHashTable *ipatch_file_pool = NULL;     // Hash of fileNames -> GWeakRef(IpatchFile)
 
+/* Initialise static hash and create IpatchFile class */
+/* ----- Initialization/deinitialization of ipatch_file pool  ---------------*/
+/* Initialise static hash  */
+void _ipatch_file_init(void)
+{
+    /* create file pool has table */
+    ipatch_file_pool = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                              g_free, ipatch_util_weakref_destroy);
+}
+
+/* Free static hash  */
+void _ipatch_file_deinit(void)
+{
+    g_hash_table_destroy(ipatch_file_pool);
+}
+
+/* ----- IpatchFileHandle object functions  ---------------------------------*/
 
 static IpatchFileHandle *
 ipatch_file_handle_duplicate(IpatchFileHandle *handle)
@@ -176,9 +193,6 @@ ipatch_file_class_init(IpatchFileClass *klass)
                                             "File Name",
                                             NULL,
                                             G_PARAM_READWRITE));
-
-    ipatch_file_pool = g_hash_table_new_full(g_str_hash, g_str_equal,
-                       g_free, ipatch_util_weakref_destroy);
 }
 
 static void

--- a/libinstpatch/IpatchParamProp.c
+++ b/libinstpatch/IpatchParamProp.c
@@ -54,6 +54,7 @@ G_LOCK_DEFINE_STATIC(param_prop_hash);
 /* GParamSpec GValue property hash */
 static GHashTable *param_prop_hash = NULL;
 
+/* Initialization/deinitialization of GParamSpec extended properties system */
 
 /**
  * _ipatch_param_init: (skip)
@@ -89,6 +90,15 @@ _ipatch_param_init(void)
     (g_param_spec_uint("unit-type", _("Units"),
                        _("Type of units used"), 0, G_MAXUINT, 0, G_PARAM_READWRITE));
 }
+
+/* Freeing GParamSpec extended properties  system */
+void
+_ipatch_param_deinit(void)
+{
+	g_hash_table_destroy(param_prop_hash);
+}
+
+/* -- API of GParamSpec extended properties  system ---------------------*/
 
 /**
  * ipatch_param_install_property:

--- a/libinstpatch/IpatchSF2Gen.c
+++ b/libinstpatch/IpatchSF2Gen.c
@@ -55,6 +55,10 @@ guint64 ipatch_sf2_gen_add_mask;
 /* array of property names by generator ID */
 static const char **gen_property_names = NULL; /* names [IPATCH_SF2_GEN_COUNT] */
 
+/*-----------------------------------------------------------------------------
+  Initialization/deinitialization of the generator subsystem
+ ----------------------------------------------------------------------------*/
+
 /**
  * _ipatch_sf2_gen_init: (skip)
  *
@@ -160,6 +164,19 @@ _ipatch_sf2_gen_init(void)
         enum_val = g_enum_get_value(enum_class, i);
         gen_property_names[i] = enum_val ? enum_val->value_nick : NULL;
     }
+}
+
+/**
+ * _ipatch_sf2_gen_deinit:
+ *
+ * Feeing SoundFont generator subsystem.
+ */
+void
+_ipatch_sf2_gen_deinit (void)
+{
+    g_free((gpointer)gen_property_names);
+    ipatch_sf2_gen_array_free(ipatch_sf2_gen_ofs_array);
+    ipatch_sf2_gen_array_free(ipatch_sf2_gen_abs_array);
 }
 
 /**

--- a/libinstpatch/IpatchSampleData.c
+++ b/libinstpatch/IpatchSampleData.c
@@ -64,6 +64,7 @@ typedef struct
     guint32 channel_map;
 } CachingInfo;
 
+static void _ipatch_sample_data_free_caching_info(CachingInfo *data);
 static void ipatch_sample_data_sample_iface_init(IpatchSampleIface *iface);
 static gboolean ipatch_sample_data_sample_iface_open(IpatchSampleHandle *handle,
         GError **err);
@@ -93,6 +94,31 @@ G_DEFINE_TYPE_WITH_CODE(IpatchSampleData, ipatch_sample_data, IPATCH_TYPE_ITEM,
                         G_IMPLEMENT_INTERFACE(IPATCH_TYPE_SAMPLE,
                                 ipatch_sample_data_sample_iface_init))
 
+/* ----- Initialization/deinitialization of lists ---------------------------*/
+/* Initialize lists */
+void _ipatch_sample_data_init(void)
+{
+    sample_cache_total_size = 0;     /* Total size of cached samples */
+    sample_cache_unused_size = 0;    /* Size of unused cached samples */
+    sample_data_list = NULL;
+    caching_list = NULL;
+}
+
+/* Free lists */
+void _ipatch_sample_data_deinit(void)
+{
+    g_slist_free(sample_data_list);
+    g_slist_free_full(caching_list,
+                     (GDestroyNotify)_ipatch_sample_data_free_caching_info);
+}
+
+/* free data list */
+static void _ipatch_sample_data_free_caching_info(CachingInfo *data)
+{
+    g_slice_free(CachingInfo, data);
+}
+
+/* ----- IpatchSampleData object functions  ---------------------------------*/
 
 /**
  * ipatch_get_sample_data_list:

--- a/libinstpatch/IpatchSampleStoreSwap.c
+++ b/libinstpatch/IpatchSampleStoreSwap.c
@@ -69,6 +69,7 @@ typedef struct
 } SwapRecover;
 
 
+static void ipatch_sample_store_swap_recover_free(SwapRecover *recover);
 static gint ipatch_sample_store_swap_recover_size_sort_func(gconstpointer a, gconstpointer b);
 static void ipatch_sample_store_swap_sample_iface_init(IpatchSampleIface *iface);
 static gboolean ipatch_sample_store_swap_sample_iface_open(IpatchSampleHandle *handle,
@@ -103,6 +104,31 @@ G_DEFINE_TYPE_WITH_CODE(IpatchSampleStoreSwap, ipatch_sample_store_swap,
                         G_IMPLEMENT_INTERFACE(IPATCH_TYPE_SAMPLE,
                                 ipatch_sample_store_swap_sample_iface_init))
 
+/* ----- Initialization/deinitialization of lists ---------------------------*/
+/* Initialize lists */
+void _ipatch_sample_store_swap_recover_init(void)
+{
+    swap_fd = -1;
+    swap_file_name = NULL;
+    swap_position = 0;             // Current position in swap file, for new sample data
+    swap_unused_size = 0;          // Amount of wasted space (unused samples)
+    swap_ram_used = 0;             // Amount of RAM memory used for swap
+    swap_ram_max = MAX_RAM_SWAP;   // Maximum amount of RAM swap storage
+    swap_list = NULL;
+    swap_recover_list = NULL;
+    swap_recover_loc_list = NULL;
+}
+
+/* Free lists */
+void _ipatch_sample_store_swap_recover_deinit(void)
+{
+    g_slist_free_full (swap_recover_list,
+		               (GDestroyNotify)ipatch_sample_store_swap_recover_free);
+    g_slist_free (swap_recover_loc_list);
+    g_free(swap_file_name);
+}
+
+/* ----- IpatchSampleStoreSwap object functions  ----------------------------*/
 static SwapRecover *
 ipatch_sample_store_swap_recover_new(void)
 {

--- a/libinstpatch/IpatchTypeProp.c
+++ b/libinstpatch/IpatchTypeProp.c
@@ -77,6 +77,9 @@ static GHashTable *type_prop_hash = NULL;
 /* hash of all GType property values (GType:GParamSpec -> GValue) */
 static GHashTable *type_prop_value_hash = NULL;
 
+/*-----------------------------------------------------------------------------
+  Initialization/deinitialization of GType property system
+ ----------------------------------------------------------------------------*/
 /**
  * _ipatch_type_prop_init: (skip)
  *
@@ -182,7 +185,10 @@ type_prop_value_destroy(gpointer user_data)
 {
     TypePropValueVal *val = (TypePropValueVal *)user_data;
 
-    g_value_unset(&val->value);
+    if(G_IS_VALUE(&val->value))
+    {
+        g_value_unset(&val->value);
+    }
 
     if(val->notify_func)
     {
@@ -190,6 +196,18 @@ type_prop_value_destroy(gpointer user_data)
     }
 
     g_slice_free(TypePropValueVal, val);
+}
+
+/**
+ * _ipatch_type_prop_deinit
+ *
+ * Free GType property system
+ */
+void
+_ipatch_type_prop_deinit (void)
+{
+    g_hash_table_destroy(type_prop_hash);
+    g_hash_table_destroy(type_prop_value_hash);
 }
 
 /**

--- a/libinstpatch/IpatchUnit.c
+++ b/libinstpatch/IpatchUnit.c
@@ -65,27 +65,51 @@ void _ipatch_unit_generic_init(void);
 void _ipatch_unit_dls_init(void);
 void _ipatch_unit_sf2_init(void);
 
-
+/*-----------------------------------------------------------------------------
+  Initialization/deinitialization of Unit conversion system
+ ----------------------------------------------------------------------------*/
 /**
  * _ipatch_unit_init: (skip)
  *
  * Initialize unit system
  */
-void
-_ipatch_unit_init(void)
+void _ipatch_unit_init (void)
 {
-    unit_id_hash = g_hash_table_new(NULL, NULL);
-    unit_name_hash = g_hash_table_new(g_str_hash, g_str_equal);
-    class_map_hash = g_hash_table_new(NULL, NULL);
-    conversion_hash = g_hash_table_new_full(NULL, NULL, NULL,
-                                            ipatch_unit_conversion_hash_val_destroy);
+    last_unit_id = IPATCH_UNIT_TYPE_FIRST_DYNAMIC_ID;
+
+    /* Create hash table to register unit by id */
+    unit_id_hash = g_hash_table_new_full(
+                                NULL, NULL, NULL,
+                                (GDestroyNotify)ipatch_unit_info_free);
+
+    /* Create hash table to register unit by name */
+    unit_name_hash = g_hash_table_new (g_str_hash, g_str_equal);
+    class_map_hash = g_hash_table_new (NULL, NULL);
+
+    /* Create the conversion hash table to register conversion function */
+    conversion_hash = g_hash_table_new_full (NULL, NULL, NULL,
+                                             ipatch_unit_conversion_hash_val_destroy);
 
     /* initialize unit types and conversion handlers */
-
-    _ipatch_unit_generic_init();
-    _ipatch_unit_dls_init();
-    _ipatch_unit_sf2_init();
+    _ipatch_unit_generic_init ();
+    _ipatch_unit_dls_init ();
+    _ipatch_unit_sf2_init ();
 }
+
+/**
+ * _ipatch_unit_deinit: (skip)
+ *
+ * Free unit system
+ */
+void _ipatch_unit_deinit(void)
+{
+    g_hash_table_destroy(unit_id_hash);
+    g_hash_table_destroy(unit_name_hash);
+    g_hash_table_destroy(class_map_hash);
+    g_hash_table_destroy(conversion_hash);
+}
+
+/* ----- Unit convertion system functions  ---------------------------------*/
 
 static void
 ipatch_unit_conversion_hash_val_destroy(gpointer data)

--- a/libinstpatch/IpatchXmlObject.c
+++ b/libinstpatch/IpatchXmlObject.c
@@ -138,7 +138,9 @@ G_LOCK_DEFINE_STATIC(xml_handlers);
 /* hash of XML handlers (HandlerHashKey -> HandlerHashValue) */
 static GHashTable *xml_handlers = NULL;
 
-
+/*-----------------------------------------------------------------------------
+  1) Initialization/deinitialization of loading/saving system
+ ----------------------------------------------------------------------------*/
 /*
  * Initialize IpatchXmlObject loading/saving system
  */
@@ -181,6 +183,15 @@ static void
 xml_handlers_value_destroy_func(gpointer data)
 {
     g_slice_free(HandlerHashValue, data);
+}
+
+/*
+ * Free IpatchXmlObject loading/saving system
+ */
+void
+_ipatch_xml_object_deinit(void)
+{
+    g_hash_table_destroy(xml_handlers);
 }
 
 /**

--- a/libinstpatch/libinstpatch.def
+++ b/libinstpatch/libinstpatch.def
@@ -56,6 +56,7 @@ ipatch_base_set_file_name
 
 ipatch_container_add_unique
 ipatch_container_add_connect
+ipatch_container_add_disconnect_matched
 ipatch_container_append
 ipatch_container_count
 ipatch_container_get_child_types
@@ -69,6 +70,7 @@ ipatch_container_make_unique
 ipatch_container_remove
 ipatch_container_remove_all
 ipatch_container_remove_connect
+ipatch_container_remove_disconnect_matched
 ipatch_container_remove_iter
 ;ipatch_container_set_add_hook
 ;ipatch_container_set_remove_hook

--- a/libinstpatch/libinstpatch.def
+++ b/libinstpatch/libinstpatch.def
@@ -2,7 +2,6 @@ LIBRARY
 EXPORTS
 
 ipatch_close
-ipatch_deinit
 
 _ipatch_code_error
 _ipatch_code_errorv

--- a/libinstpatch/libinstpatch.def
+++ b/libinstpatch/libinstpatch.def
@@ -1,6 +1,9 @@
 LIBRARY
 EXPORTS
 
+ipatch_close
+ipatch_deinit
+
 _ipatch_code_error
 _ipatch_code_errorv
 _ipatch_convert_DLS2_init

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -60,6 +60,7 @@ void _ipatch_sf2_voice_cache_init_SLI(void);
 void _ipatch_sf2_voice_cache_init_gig(void);
 void _ipatch_sf2_voice_cache_init_VBank(void);
 void _ipatch_container_notify_init(void);
+void _ipatch_DLS2_infos_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -69,6 +70,8 @@ void _ipatch_xml_object_deinit(void);
 void _ipatch_util_deinit(void);
 void _ipatch_sf2_gen_deinit(void);
 void _ipatch_container_notify_deinit(void);
+void _ipatch_DLS2_infos_deinit(void);
+
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -206,6 +209,7 @@ ipatch_init(void)
      Respective function _xxx_deinit() are called in ipatch_deinit().
     -------------------------------------------------------------------------*/
     _ipatch_container_notify_init();
+    _ipatch_DLS2_infos_init();
 
     /*-------------------------------------------------------------------------
      initialize interfaces type before objects
@@ -489,6 +493,9 @@ ipatch_deinit(void)
     -------------------------------------------------------------------------*/
     /* Free container subsystem */
     _ipatch_container_notify_deinit();
+
+    /* Free DLS2 subsystem */
+    _ipatch_DLS2_infos_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -66,6 +66,7 @@ void _ipatch_file_init(void);
 void _ipatch_item_init(void);
 void _ipatch_sample_data_init(void);
 void _ipatch_sample_store_swap_recover_init(void);
+void _ipatch_converter_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -81,6 +82,7 @@ void _ipatch_file_deinit(void);
 void _ipatch_item_deinit(void);
 void _ipatch_sample_data_deinit(void);
 void _ipatch_sample_store_swap_recover_deinit(void);
+void _ipatch_converter_deinit(void);
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
                                        GParamSpec *pspec, GValue *value,
@@ -223,6 +225,7 @@ ipatch_init(void)
     _ipatch_item_init();
     _ipatch_sample_data_init();
     _ipatch_sample_store_swap_recover_init();
+    _ipatch_converter_init();
 
     /*-------------------------------------------------------------------------
      initialize interfaces type before objects
@@ -524,6 +527,9 @@ ipatch_deinit(void)
 
     /* Free Sample store swap recovery subsystem */
     _ipatch_sample_store_swap_recover_deinit();
+
+    /* Free converter subsytem */
+    _ipatch_converter_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -65,6 +65,7 @@ void _ipatch_param_deinit(void);
 void _ipatch_type_prop_deinit(void);
 void _ipatch_unit_deinit(void);
 void _ipatch_xml_object_deinit(void);
+void _ipatch_util_deinit(void);
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -187,6 +188,8 @@ ipatch_init(void)
 
     /* Initialize object's properties 'encoding/decoding XML handlers' system */
     _ipatch_xml_object_init();
+
+    /* Initialize GValue constant values */
     _ipatch_util_init();
     _ipatch_sf2_gen_init();
 
@@ -451,6 +454,9 @@ ipatch_deinit(void)
 
     /* Free object's properties 'encoding/decoding XML handlers' system */
     _ipatch_xml_object_deinit();
+
+    /* Free GValue constant values */
+    _ipatch_util_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -148,14 +148,14 @@ static gboolean initialized = FALSE;
 
 /*-----------------------------------------------------------------------------
  Initialization / deinitialization of libinstpatch library.
- Any application sould call ipatch_init() once before any others libinstpatch
+ Any application should call ipatch_init() once before any other libinstpatch
  functions.
- When the application finished it must call ipatch_close().
+ When the application is complete it must call ipatch_close().
 
  For multi task application it is best that only one task be responsible of
  initialization/closing. Typically, the main task of the application should
- call ipatch_init() before creating other tasks, then when the application
- finished, the main task should call ipatch_close() after the other tasks are
+ call ipatch_init() before creating other tasks, then when the application is
+ complete, the main task should call ipatch_close() after the other tasks are
  completed.
 -----------------------------------------------------------------------------*/
 

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -62,6 +62,7 @@ void _ipatch_sf2_voice_cache_init_VBank(void);
 void _ipatch_container_notify_init(void);
 void _ipatch_DLS2_infos_init(void);
 void _ipatch_DLS2_sample_init(void);
+void _ipatch_file_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -73,6 +74,7 @@ void _ipatch_sf2_gen_deinit(void);
 void _ipatch_container_notify_deinit(void);
 void _ipatch_DLS2_infos_deinit(void);
 void _ipatch_DLS2_sample_deinit(void);
+void _ipatch_file_deinit(void);
 
 
 
@@ -213,6 +215,7 @@ ipatch_init(void)
     _ipatch_container_notify_init();
     _ipatch_DLS2_infos_init();
     _ipatch_DLS2_sample_init();
+    _ipatch_file_init();
 
     /*-------------------------------------------------------------------------
      initialize interfaces type before objects
@@ -502,6 +505,9 @@ ipatch_deinit(void)
 
     /* Free DLS2 sample subsystem */
     _ipatch_DLS2_sample_deinit();
+
+    /* Free File subsystem */
+    _ipatch_file_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -65,6 +65,7 @@ void _ipatch_DLS2_sample_init(void);
 void _ipatch_file_init(void);
 void _ipatch_item_init(void);
 void _ipatch_sample_data_init(void);
+void _ipatch_sample_store_swap_recover_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -79,6 +80,7 @@ void _ipatch_DLS2_sample_deinit(void);
 void _ipatch_file_deinit(void);
 void _ipatch_item_deinit(void);
 void _ipatch_sample_data_deinit(void);
+void _ipatch_sample_store_swap_recover_deinit(void);
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
                                        GParamSpec *pspec, GValue *value,
@@ -220,6 +222,7 @@ ipatch_init(void)
     _ipatch_file_init();
     _ipatch_item_init();
     _ipatch_sample_data_init();
+    _ipatch_sample_store_swap_recover_init();
 
     /*-------------------------------------------------------------------------
      initialize interfaces type before objects
@@ -518,6 +521,9 @@ ipatch_deinit(void)
 
     /* Free Sample data subsystem */
     _ipatch_sample_data_deinit();
+
+    /* Free Sample store swap recovery subsystem */
+    _ipatch_sample_store_swap_recover_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -59,6 +59,7 @@ void _ipatch_sf2_voice_cache_init_SF2(void);
 void _ipatch_sf2_voice_cache_init_SLI(void);
 void _ipatch_sf2_voice_cache_init_gig(void);
 void _ipatch_sf2_voice_cache_init_VBank(void);
+void _ipatch_container_notify_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -67,6 +68,7 @@ void _ipatch_unit_deinit(void);
 void _ipatch_xml_object_deinit(void);
 void _ipatch_util_deinit(void);
 void _ipatch_sf2_gen_deinit(void);
+void _ipatch_container_notify_deinit(void);
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -196,6 +198,18 @@ ipatch_init(void)
     /* Initialize 'SoundFont generators' subsystem */
     _ipatch_sf2_gen_init();
 
+    /*------------------------------------------------------------------------
+     Initialize object subsystem (list, hash) before objects type.
+     These list or hash are specfific to the respective object.
+     Initialization/free functions are in the respective object module file
+     Here initialization function _xxx_init() are called.
+     Respective function _xxx_deinit() are called in ipatch_deinit().
+    -------------------------------------------------------------------------*/
+    _ipatch_container_notify_init();
+
+    /*-------------------------------------------------------------------------
+     initialize interfaces type before objects
+    --------------------------------------------------------------------------*/
     /* initialize interfaces before objects */
     ipatch_sample_get_type();
     ipatch_sf2_gen_item_get_type();
@@ -463,6 +477,18 @@ ipatch_deinit(void)
 
     /* Free 'SoundFont generators' subsystem */
     _ipatch_sf2_gen_deinit();
+
+    /*-------------------------------------------------------------------------
+     Free object subsystem (list, hash).
+     These list or hash are specfific to the respective object.
+     Initialization/deinitialization functions are in the respective object
+     module file.
+     Here deinitialization functions  _xxx_deinit() are called.
+     Respective initialization functions _xxx_init() are called in
+     ipatch_init().
+    -------------------------------------------------------------------------*/
+    /* Free container subsystem */
+    _ipatch_container_notify_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -63,6 +63,8 @@ void _ipatch_container_notify_init(void);
 void _ipatch_DLS2_infos_init(void);
 void _ipatch_DLS2_sample_init(void);
 void _ipatch_file_init(void);
+void _ipatch_item_init(void);
+void _ipatch_sample_data_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -75,8 +77,8 @@ void _ipatch_container_notify_deinit(void);
 void _ipatch_DLS2_infos_deinit(void);
 void _ipatch_DLS2_sample_deinit(void);
 void _ipatch_file_deinit(void);
-
-
+void _ipatch_item_deinit(void);
+void _ipatch_sample_data_deinit(void);
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
                                        GParamSpec *pspec, GValue *value,
@@ -216,6 +218,8 @@ ipatch_init(void)
     _ipatch_DLS2_infos_init();
     _ipatch_DLS2_sample_init();
     _ipatch_file_init();
+    _ipatch_item_init();
+    _ipatch_sample_data_init();
 
     /*-------------------------------------------------------------------------
      initialize interfaces type before objects
@@ -508,6 +512,12 @@ ipatch_deinit(void)
 
     /* Free File subsystem */
     _ipatch_file_deinit();
+
+    /* Free Item propterty subsystem */
+    _ipatch_item_deinit();
+
+    /* Free Sample data subsystem */
+    _ipatch_sample_data_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -64,6 +64,7 @@ void _ipatch_sf2_voice_cache_init_VBank(void);
 void _ipatch_param_deinit(void);
 void _ipatch_type_prop_deinit(void);
 void _ipatch_unit_deinit(void);
+void _ipatch_xml_object_deinit(void);
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -183,6 +184,8 @@ ipatch_init(void)
 
     /* Initialize 'unit conversion' system */
     _ipatch_unit_init();
+
+    /* Initialize object's properties 'encoding/decoding XML handlers' system */
     _ipatch_xml_object_init();
     _ipatch_util_init();
     _ipatch_sf2_gen_init();
@@ -445,6 +448,9 @@ ipatch_deinit(void)
 
     /* Free 'unit conversion' system */
     _ipatch_unit_deinit();
+
+    /* Free object's properties 'encoding/decoding XML handlers' system */
+    _ipatch_xml_object_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -62,6 +62,7 @@ void _ipatch_sf2_voice_cache_init_VBank(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
+void _ipatch_type_prop_deinit(void);
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -172,7 +173,11 @@ ipatch_init(void)
 #endif
 
     /* Must be done before other types since they may be dependent */
+
+    /* Initialize 'GParamSpec extended properties' system */
     _ipatch_param_init();
+
+    /* Initialize the 'GObject style properties' system for GTypes */
     _ipatch_type_prop_init();
     _ipatch_unit_init();
     _ipatch_xml_object_init();
@@ -431,6 +436,9 @@ ipatch_deinit(void)
     -------------------------------------------------------------------------*/
     /* Free 'GParamSpec extended properties' system */
     _ipatch_param_deinit();
+
+    /* Free the 'GObject style properties' system for GTypes */
+    _ipatch_type_prop_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -66,6 +66,7 @@ void _ipatch_type_prop_deinit(void);
 void _ipatch_unit_deinit(void);
 void _ipatch_xml_object_deinit(void);
 void _ipatch_util_deinit(void);
+void _ipatch_sf2_gen_deinit(void);
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -191,6 +192,8 @@ ipatch_init(void)
 
     /* Initialize GValue constant values */
     _ipatch_util_init();
+
+    /* Initialize 'SoundFont generators' subsystem */
     _ipatch_sf2_gen_init();
 
     /* initialize interfaces before objects */
@@ -457,6 +460,9 @@ ipatch_deinit(void)
 
     /* Free GValue constant values */
     _ipatch_util_deinit();
+
+    /* Free 'SoundFont generators' subsystem */
+    _ipatch_sf2_gen_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -63,6 +63,7 @@ void _ipatch_sf2_voice_cache_init_VBank(void);
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
 void _ipatch_type_prop_deinit(void);
+void _ipatch_unit_deinit(void);
 
 
 static gboolean ipatch_strv_xml_encode(GNode *node, GObject *object,
@@ -179,6 +180,8 @@ ipatch_init(void)
 
     /* Initialize the 'GObject style properties' system for GTypes */
     _ipatch_type_prop_init();
+
+    /* Initialize 'unit conversion' system */
     _ipatch_unit_init();
     _ipatch_xml_object_init();
     _ipatch_util_init();
@@ -439,6 +442,9 @@ ipatch_deinit(void)
 
     /* Free the 'GObject style properties' system for GTypes */
     _ipatch_type_prop_deinit();
+
+    /* Free 'unit conversion' system */
+    _ipatch_unit_deinit();
 }
 
 /**

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -469,7 +469,7 @@ ipatch_init(void)
  * Free libInstPatch library. Should be called when the application have
  * finished.
  */
-void
+static void
 ipatch_deinit(void)
 {
     if (!initialized)

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -61,6 +61,7 @@ void _ipatch_sf2_voice_cache_init_gig(void);
 void _ipatch_sf2_voice_cache_init_VBank(void);
 void _ipatch_container_notify_init(void);
 void _ipatch_DLS2_infos_init(void);
+void _ipatch_DLS2_sample_init(void);
 
 /* private free functions in other source files */
 void _ipatch_param_deinit(void);
@@ -71,6 +72,7 @@ void _ipatch_util_deinit(void);
 void _ipatch_sf2_gen_deinit(void);
 void _ipatch_container_notify_deinit(void);
 void _ipatch_DLS2_infos_deinit(void);
+void _ipatch_DLS2_sample_deinit(void);
 
 
 
@@ -210,6 +212,7 @@ ipatch_init(void)
     -------------------------------------------------------------------------*/
     _ipatch_container_notify_init();
     _ipatch_DLS2_infos_init();
+    _ipatch_DLS2_sample_init();
 
     /*-------------------------------------------------------------------------
      initialize interfaces type before objects
@@ -496,6 +499,9 @@ ipatch_deinit(void)
 
     /* Free DLS2 subsystem */
     _ipatch_DLS2_infos_deinit();
+
+    /* Free DLS2 sample subsystem */
+    _ipatch_DLS2_sample_deinit();
 }
 
 /**

--- a/libinstpatch/util.c
+++ b/libinstpatch/util.c
@@ -53,6 +53,21 @@ _ipatch_util_init(void)
 }
 
 /**
+ * _ipatch_util_deinit
+ *
+ * Free GValue values
+ */
+void
+_ipatch_util_deinit(void)
+{
+    g_value_unset(ipatch_util_value_bool_true);
+    g_value_unset(ipatch_util_value_bool_false);
+
+    g_free(ipatch_util_value_bool_true);
+    g_free(ipatch_util_value_bool_false);
+}
+
+/**
  * ipatch_util_value_hash:
  * @val: GValue to hash
  *


### PR DESCRIPTION
The new function `ipatch_deinit() `is incorporated in `ipatch_close()` function API.
- Typically the application should call `ipatch_init() `before using any other functions.
- Then the application should call `ipatch_close() `when finished. This ensures freeing the memory allocated during ipatch_init().

Note: `ipatch_deinit()` has been incorporated in` ipatch_close() `because ipatch_close() is already a function API. This avoid changing actual version number. 
