### PR TITLE
fix finalize operation in ipatch_sf2_voice_cache_finalize()

### DIFF
--- a/libinstpatch/IpatchSF2VoiceCache.c
+++ b/libinstpatch/IpatchSF2VoiceCache.c
@@ -130,13 +130,13 @@ ipatch_sf2_voice_cache_finalize(GObject *gobject)
 
     g_free(cache->sel_info);
 
-	/*-------- free IpatchSF2Voice field members -------------------------------*/
+    /*-------- free IpatchSF2Voice field members -------------------------------*/
     for(i = 0; i < cache->voices->len; i++)
     {
         voice = &g_array_index(cache->voices, IpatchSF2Voice, i);
 
         /* running voice_user_data_destroy() function first ensures that the
-           function could expect that any IpatchSF2Voice field members is
+           function could expect that any IpatchSF2Voice field member is
            still valid. This is necessarry if the parameter voice->user_data
            is a pointer to one of this field.
         */


### PR DESCRIPTION
This PR fixes 3 issues

fix 1:  issue that occurs when a `IpatchSF2VoiceCache` object is freed.

For example using swami:

After loading a soundfont , playing some notes on one instrument zone than playing notes on another instrument zone,... such a `IpatchSF2VoiceCache` is used by the `fluidsynth plugin`. Then when the application exits this `IpatchSF2VoiceCache` is freed when `voice_cache_hash` is freed. This produces most critical messages:

`** (swami1.exe:7248): CRITICAL **: file ..IpatchSampleStoreCache.c: line 306: assertion IPATCH_IS_SAMPLE_STORE_CACHE (store) failed`

This is because when`IpatchSF2VoiceCache` is freed, `ipatch_sample_store_cache_close(store) `is called (via `cache->voice_user_data_destroy()`) and `store`parameter is no more valid because it is already freed before `cache->voice_user_data_destroy()`is called.

To fix this issue, the ordering of operation in `ipatch_sf2_voice_cache_finalize()` is changed to
ensure that `voice_user_data_destroy()` function can work properly.
***
fix 2: For coherency with the change done in `fix 1`,  `cache->user_data_destroy` ordering is changed also.
***

fix 3: free `overides_mods` list.