### PR TITLE
Fix a bug in paste operations.

### DIFF
--- a/libinstpatch/IpatchItem.c
+++ b/libinstpatch/IpatchItem.c
@@ -1163,7 +1163,6 @@ ipatch_item_copy_link_func(IpatchItem *dest, IpatchItem *src,
 
     g_return_if_fail(IPATCH_IS_ITEM(dest));
     g_return_if_fail(IPATCH_IS_ITEM(src));
-    g_return_if_fail(link_func != NULL);
 
     dest_type = G_OBJECT_TYPE(dest);
     src_type = G_OBJECT_TYPE(src);


### PR DESCRIPTION
During a **copy/paste** of `instrument zones` in an `Instrument` (or **copy/paste** of `preset zones` in a `Preset`), paste operation fails. For example in **swami**  following critical messages occur.

- ** (swami1.exe:6236): CRITICAL **: file ..\..\..\libinstpatch-1.0.0\libinstpatch\IpatchItem.c: line 1166: assertion `link_func != NULL' failed

- ** (swami1.exe:6236): CRITICAL **: file ..\..\..\swami-2.0.0\src\swamigui\SwamiguiTreeStorePatch.c: line 367: assertion `title != NULL' failed.

The bug is in` ipatch_item_copy_link_func()`. This function is called by `ipatch_item_duplicate()` or `ipatch_item_duplicate_link_func()`. In the case of `ipatch_item_duplicate()`, the function is called by `ipatch_item_copy()` using the class method `klass->copy(dest, src, NULL, NULL)`.
As the method implemented by derived **IpatchItem** objects (IpatchSF2Inst, IpatchSF2Preset,...) is calling `ipatch_item_duplicate_link_func()`, that leads to `link_func` parameter set to NULL which is a valid parameter.

ipatch_item_copy_link_func(), should ignore if `link_func` parameter is NULL.