### PR TITLE
Amend the message of PR 43

### DIFF
--- a/libinstpatch/IpatchItem.c
+++ b/libinstpatch/IpatchItem.c
@@ -1163,7 +1163,6 @@ ipatch_item_copy_link_func(IpatchItem *dest, IpatchItem *src,
 
     g_return_if_fail(IPATCH_IS_ITEM(dest));
     g_return_if_fail(IPATCH_IS_ITEM(src));
-    g_return_if_fail(link_func != NULL);
 
     dest_type = G_OBJECT_TYPE(dest);
     src_type = G_OBJECT_TYPE(src);


### PR DESCRIPTION
During a copy/paste of Instrument(s) (or Preset(s)),
paste operation fails. The bug is in ipatch_item_copy_link_func().

This function is called by ipatch_item_duplicate() or ipatch_item_duplicate_link_func().
In the case of ipatch_item_duplicate(), the function is called by
ipatch_item_copy() using the class method klass->copy(dest, src, NULL, NULL).
As the method implemented by derived IpatchItem objects (IpatchSF2Inst,
IpatchSF2Preset,...) is calling ipatch_item_copy_link_func(), that leads to link_func
parameter set to NULL which is a valid parameter.

ipatch_item_copy_link_func(), should ignore if link_func is NULL.