### PR TITLE
Adding a safe reference counter for initialization/deinitialization

### DIFF
--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -481,12 +481,6 @@ ipatch_init(void)
 static void
 ipatch_deinit(void)
 {
-    if (!initialized)
-    {
-        return;
-    }
-    initialized = FALSE;
-
     g_free(ipatch_application_name);
 
     /*-------------------------------------------------------------------------
@@ -564,6 +558,12 @@ ipatch_deinit(void)
 void
 ipatch_close(void)
 {
+    if (!initialized)
+    {
+        return;
+    }
+
+    initialized = FALSE;
     ipatch_sample_store_swap_close();
     ipatch_deinit();
 }

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -486,6 +486,9 @@ ipatch_deinit(void)
         return;
     }
     initialized = FALSE;
+
+    g_free(ipatch_application_name);
+
     /*-------------------------------------------------------------------------
       Free internal systems
     -------------------------------------------------------------------------*/

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -559,10 +559,14 @@ ipatch_deinit(void)
 /**
  * ipatch_close:
  *
- * Perform cleanup of libInstPatch prior to application close.  Such as deleting
- * temporary files.
- * Does nothing if the library is already deinitialized or if the library
- * is still owned (see ipatch_init()).
+ * This should be called prior to application close.
+ *
+ * Decrement the reference counter and if it reaches 0 performs cleanup of
+ * libInstPatch, such as deleting temporary files and internal caches.
+ * If the counter is still > 0, the function return without doing cleanup
+ * (the library is still owned).
+ *
+ * Does nothing if the library is already deinitialized (or was not initialized).
  * Since: 1.1.0
  */
 void
@@ -573,7 +577,7 @@ ipatch_close(void)
     init_counter--;
     if(init_counter != 0)
     {
-        /* library still owned by a task, do noth */
+        /* library still owned by a task, do nothing */
         if(init_counter < 0)
         {
             init_counter = 0;


### PR DESCRIPTION
This counter is necessary, when the application makes use of `multiples libraries` each dependent of `libinstpatch`. Examples: 
- `Swami `is dependent of `libinstpatch `and `fluidsynth`. `fluidsynth `could be optionally dependent of `libinstpatch`. In this case `libinstpatch `is owned twice (by `swami `and by `fluidsynth`).
- For an application only dependent of `fluidsynth`, `libinstpatch `is only owned by `fluidsynth`.
- For an application only dependent of `libinstpatch`, `libinstpatch `is only owned by this application.

This counter ensures that internal `initialization `(or `deinitialization`) is done only one time.
This is required because `libinstpatch `is dependent of `GObject` which doesn't accept that the same `Gtype` be registered multiple times.
