### PR TITLE
CI Debug Windows build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,8 @@ jobs:
         @ECHO ON
         SET "PATH=d:\deps\bin;%PATH%"
         mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 15 2017" -T "v141_xp" -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
-        cmake --build . --config Release --target install || exit -1
+        cmake -G "Visual Studio 15 2017" -T "v141_xp" -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
+        cmake --build . --config Debug --target install || exit -1
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
@@ -98,8 +98,8 @@ jobs:
         @ECHO ON
         SET "PATH=d:\deps\bin;%PATH%"
         mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 15 2017 Win64" -T "v141_xp" -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
-        cmake --build . --config Release --target install || exit -1
+        cmake -G "Visual Studio 15 2017 Win64" -T "v141_xp" -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
+        cmake --build . --config Debug --target install || exit -1
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll

--- a/libinstpatch/CMakeLists.txt
+++ b/libinstpatch/CMakeLists.txt
@@ -372,6 +372,9 @@ install ( TARGETS libinstpatch
   BUNDLE DESTINATION ${BUNDLE_INSTALL_DIR}
 )
 
+install(FILES $<TARGET_PDB_FILE:libinstpatch> DESTINATION ${BIN_INSTALL_DIR} OPTIONAL)
+
+
 macro(_list_prefix _outvar _listvar _prefix)
   set(${_outvar})
   foreach(_item IN LISTS ${_listvar})

--- a/libinstpatch/CMakeLists.txt
+++ b/libinstpatch/CMakeLists.txt
@@ -372,8 +372,9 @@ install ( TARGETS libinstpatch
   BUNDLE DESTINATION ${BUNDLE_INSTALL_DIR}
 )
 
-install(FILES $<TARGET_PDB_FILE:libinstpatch> DESTINATION ${BIN_INSTALL_DIR} OPTIONAL)
-
+if ( MSVC )
+  install(FILES $<TARGET_PDB_FILE:libinstpatch> DESTINATION ${BIN_INSTALL_DIR} OPTIONAL)
+endif ( MSVC )
 
 macro(_list_prefix _outvar _listvar _prefix)
   set(${_outvar})


### PR DESCRIPTION
Make sure the CI build produces PDBs on Windows and install them if existing.