### PR TITLE
Add getter functions for SLI soundfont

### DIFF
--- a/libinstpatch/IpatchSLIInst.h
+++ b/libinstpatch/IpatchSLIInst.h
@@ -136,7 +136,11 @@ struct _IpatchSLIInstCatMapEntry
 
 /* Defined in IpatchSLIInst_CatMaps.c */
 extern const char *ipatch_sli_inst_cat_strings[];
+/* getter fonction that returns pointer on ipatch_sli_inst_cat_strings table */
+extern const gchar **ipatch_sli_inst_get_cat_strings(void);
 extern const IpatchSLIInstCatMapEntry ipatch_sli_inst_cat_map[];
+/* getter fonction that returns pointer on ipatch_sli_inst_cat_map table */
+extern const IpatchSLIInstCatMapEntry * ipatch_sli_inst_get_cat_map(void);
 
 /* SoundFont instrument item */
 struct _IpatchSLIInst

--- a/libinstpatch/IpatchSLIInst_CatMaps.c
+++ b/libinstpatch/IpatchSLIInst_CatMaps.c
@@ -160,3 +160,21 @@ const IpatchSLIInstCatMapEntry ipatch_sli_inst_cat_map[] =
     { 'D', IPATCH_SLI_INST_CAT_D_SYNTH, ipatch_sli_inst_subcat_map_dsynth },
     { '@', IPATCH_SLI_INST_CAT_OTHER, NULL }
 };
+
+/**
+ * Getter fonction to access ipatch_sli_inst_cat_map[] table
+ * @return pointer on ipatch_sli_inst_cat_map[] table
+ */
+const IpatchSLIInstCatMapEntry * ipatch_sli_inst_get_cat_map(void)
+{
+    return ipatch_sli_inst_cat_map;
+}
+
+/**
+ * Getter fonction to access ipatch_sli_inst_cat_map[] table
+ * @return pointer on ipatch_sli_inst_cat_strings[] table
+ */
+const char **ipatch_sli_inst_get_cat_strings(void)
+{
+    return ipatch_sli_inst_cat_strings;
+}

--- a/libinstpatch/libinstpatch.def
+++ b/libinstpatch/libinstpatch.def
@@ -885,9 +885,13 @@ ipatch_sf2_zone_next
 ipatch_strconcat_num
 
 ipatch_sli_get_type
-ipatch_sli_inst_cat_strings
+;ipatch_sli_inst_cat_strings
+;getter fonction that returns pointer on ipatch_sli_inst_cat_strings table
+ipatch_sli_inst_get_cat_strings
 ipatch_sli_sample_get_type
-ipatch_sli_inst_cat_map
+;ipatch_sli_inst_cat_map
+;getter fonction that returns pointer on ipatch_sli_inst_cat_map table
+ipatch_sli_inst_get_cat_map
 ipatch_sli_inst_get_category_as_path
 ipatch_sli_inst_get_type
 ipatch_sli_zone_get_type


### PR DESCRIPTION
-ipatch_sli_inst_get_cat_map().
-ipatch_sli_inst_get_cat_strings().
This functions allow libinstpatch to be called as a shared library.

This allows swami to access table in libinstpatch without violation access (PR https://github.com/swami/swami/pull/56 ).