### PR TITLE
fix segmentation fault taking its origin during  IpatchDLS2 to file conversion

### DIFF
--- a/libinstpatch/IpatchDLS2Info.c
+++ b/libinstpatch/IpatchDLS2Info.c
@@ -238,7 +238,7 @@ ipatch_dls2_info_duplicate(IpatchDLS2Info *info)
         newbag = ipatch_dls2_info_bag_new();
         newbag->fourcc = bag->fourcc;
         newbag->value = g_strdup(bag->value);
-        newinfo = g_slist_prepend(newinfo, bag);
+        newinfo = g_slist_prepend(newinfo, newbag);
 
         p = g_slist_next(p);
     }


### PR DESCRIPTION
This PR fixes issue https://github.com/swami/swami/issues/55 point 2.3.

-  Because **bag** data belongs to original `IpatchDLS2 object`, when **newinfo** will be freed this will corrupt original IpatchDLS2.
- Then, attempting to save this `original IpatchDLS2` **corrupted** object a second time leads to a segmentation fault.