### PR TITLE
fix missing flags (saved,changed) initialization

### DIFF
--- a/libinstpatch/IpatchDLSReader.c
+++ b/libinstpatch/IpatchDLSReader.c
@@ -530,6 +530,9 @@ ipatch_dls_reader_fixup(IpatchDLSReader *reader, GError **err)
     g_hash_table_destroy(fixup_hash);  /* destroy fixup hash */
     reader->needs_fixup = FALSE;
 
+    /* reset changed state (set by ipatch_dls_reader_fixup()*/
+    g_object_set (IPATCH_BASE(reader->dls), "changed", FALSE, NULL);
+
     return (TRUE);
 }
 

--- a/libinstpatch/IpatchDLSWriter.c
+++ b/libinstpatch/IpatchDLSWriter.c
@@ -286,6 +286,11 @@ ipatch_dls_writer_save(IpatchDLSWriter *writer, GError **err)
         goto err;
     }
 
+    /* reset flag "changed" to false. set flag "saved" to true */
+    g_object_set (writer->orig_dls,
+                  "changed", FALSE, /* file and object are in sync */
+                  "saved", TRUE,    /* has now been saved */
+                  NULL);
     /* </DLS > */
 
     return (TRUE);


### PR DESCRIPTION
1)This PR fixes missing initialization after a file has been written.

In ipatch_dls_writer_save():
- the flag `"saved"`, must be set to indicate that the file has been saved.
- the flag `"changed"` must be reset to indicate there is not change.

2)Also after loading a dls file , in ipatch_dls_reader_fixup(), `"changed"` flag is reset. This fix https://github.com/swami/swami/issues/55 point 2.1