### PR TITLE
Windows CI: Compile for IA32

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
         SET "PATH=d:\deps\bin;%PATH%"
         DEL /F C:\Strawberry\perl\bin\pkg-config.bat
         mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 16 2019" -T $(toolset) -A $(platform) -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
+        cmake -G "Visual Studio 16 2019" -T $(toolset) -A $(platform) -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=1 .. || exit -1
         cmake --build . --config RelWithDebInfo --target install || exit -1
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,12 +36,35 @@ jobs:
         make
       displayName: 'Compile libinstpatch'
 
-- job: WindowsXP_VS2017_x86
+- job: Windows
   pool:
-    vmImage: 'vs2017-win2016'
-  variables:
-    gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip'
-    libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w32.zip'
+    vmImage: 'windows-2019'
+  strategy:
+    matrix:
+      x86:
+        gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip'
+        libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w32.zip'
+        platform: 'Win32'
+        toolset: 'v142'
+        artifactName: 'libinstpatch-x86'
+      x64:
+        gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip'
+        libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w64.zip'
+        platform: 'x64'
+        toolset: 'v142'
+        artifactName: 'libinstpatch-x64'
+      XP_x86:
+        gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip'
+        libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w32.zip'
+        platform: 'Win32'
+        toolset: 'v141_xp'
+        artifactName: 'libinstpatch-XP-x86'
+      XP_x64:
+        gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip'
+        libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w64.zip'
+        platform: 'x64'
+        toolset: 'v141_xp'
+        artifactName: 'libinstpatch-XP-x64'
   steps:
     - script: |
         @ECHO ON
@@ -60,8 +83,8 @@ jobs:
         SET "PATH=d:\deps\bin;%PATH%"
         DEL /F C:\Strawberry\perl\bin\pkg-config.bat
         mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 15 2017" -T "v141_xp" -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
-        cmake --build . --config Debug --target install || exit -1
+        cmake -G "Visual Studio 16 2019" -T $(toolset) -A $(platform) -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
+        cmake --build . --config RelWithDebInfo --target install || exit -1
         del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
         del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
         del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
@@ -74,100 +97,4 @@ jobs:
     - task: PublishBuildArtifacts@1
       inputs:
           pathtoPublish: $(Build.ArtifactStagingDirectory)
-          artifactName: libinstpatch-Win32
-
-- job: WindowsXP_VS2017_x64
-  pool:
-    vmImage: 'vs2017-win2016'
-  variables:
-    gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip'
-    libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w64.zip'
-  steps:
-    - script: |
-        @ECHO ON
-        mkdir d:\deps || exit -1
-        cd d:\deps || exit -1
-        curl -LfsS -o gtk-bundle-dev.zip $(gtk-bundle) || exit -1
-        curl -LfsS -o libsndfile-dev.zip $(libsndfile-url) || exit -1
-        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
-        7z x -aos -- libsndfile-dev.zip > NUL || exit -1
-        REM need to fix the naming of libsndfile otherwise the linker won't find it
-        mv lib\libsndfile-1.lib lib\sndfile.lib || exit -1
-        mv lib\libsndfile-1.def lib\sndfile.def || exit -1
-      displayName: 'Prerequisites'
-    - script: |
-        @ECHO ON
-        SET "PATH=d:\deps\bin;%PATH%"
-        DEL /F C:\Strawberry\perl\bin\pkg-config.bat
-        mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 15 2017 Win64" -T "v141_xp" -DLIB_SUFFIX="" -DCMAKE_INSTALL_PREFIX=$(Build.ArtifactStagingDirectory) -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
-        cmake --build . --config Debug --target install || exit -1
-        del $(Build.ArtifactStagingDirectory)\bin\concrt*.dll
-        del $(Build.ArtifactStagingDirectory)\bin\vcruntime*.dll
-        del $(Build.ArtifactStagingDirectory)\bin\msvcp*.dll
-      displayName: 'Compile libinstpatch'
-    - bash: |
-        set -ex
-        art_dir=$(echo "$(Build.ArtifactStagingDirectory)" | sed 's/\\/\//g' | sed 's|\([a-zA-Z]\):|/\1|')
-        cp d:/deps/bin/libglib*.dll d:/deps/bin/libgobject*.dll d:/deps/bin/libgthread*.dll d:/deps/bin/*intl*.dll d:/deps/bin/libsndfile*.dll $art_dir/bin
-      displayName: 'Copy Artifacts'
-    - task: PublishBuildArtifacts@1
-      inputs:
-          pathtoPublish: $(Build.ArtifactStagingDirectory)
-          artifactName: libinstpatch-x64
-
-- job: Windows_VS2019_x86
-  pool:
-    vmImage: 'windows-2019'
-  variables:
-    gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip'
-    libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w32.zip'
-  steps:
-    - script: |
-        @ECHO ON
-        mkdir d:\deps || exit -1
-        cd d:\deps || exit -1
-        curl -LfsS -o gtk-bundle-dev.zip $(gtk-bundle) || exit -1
-        curl -LfsS -o libsndfile-dev.zip $(libsndfile-url) || exit -1
-        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
-        7z x -aos -- libsndfile-dev.zip > NUL || exit -1
-        REM need to fix the naming of libsndfile otherwise the linker won't find it
-        mv lib\libsndfile-1.lib lib\sndfile.lib || exit -1
-        mv lib\libsndfile-1.def lib\sndfile.def || exit -1
-      displayName: 'Prerequisites'
-    - script: |
-        @ECHO ON
-        SET "PATH=d:\deps\bin;%PATH%"
-        DEL /F C:\Strawberry\perl\bin\pkg-config.bat
-        mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_INSTALL_PREFIX=$HOME/libinstpatch_install -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
-        cmake --build . || exit 1
-      displayName: 'Compile libinstpatch'
-
-- job: Windows_VS2019_x64
-  pool:
-    vmImage: 'windows-2019'
-  variables:
-    gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip'
-    libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w64.zip'
-  steps:
-    - script: |
-        @ECHO ON
-        mkdir d:\deps || exit -1
-        cd d:\deps || exit -1
-        curl -LfsS -o gtk-bundle-dev.zip $(gtk-bundle) || exit -1
-        curl -LfsS -o libsndfile-dev.zip $(libsndfile-url) || exit -1
-        7z x -aos -- gtk-bundle-dev.zip > NUL || exit -1
-        7z x -aos -- libsndfile-dev.zip > NUL || exit -1
-        REM need to fix the naming of libsndfile otherwise the linker won't find it
-        mv lib\libsndfile-1.lib lib\sndfile.lib || exit -1
-        mv lib\libsndfile-1.def lib\sndfile.def || exit -1
-      displayName: 'Prerequisites'
-    - script: |
-        @ECHO ON
-        SET "PATH=d:\deps\bin;%PATH%"
-        DEL /F C:\Strawberry\perl\bin\pkg-config.bat
-        mkdir build && cd build || exit -1
-        cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=$HOME/libinstpatch_install -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=0 .. || exit -1
-        cmake --build . || exit 1
-      displayName: 'Compile libinstpatch'
+          artifactName: $(artifactName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,8 @@ jobs:
         platform: 'Win32'
         toolset: 'v141_xp'
         artifactName: 'libinstpatch-XP-x86'
+        CFLAGS: '/arch:IA32'
+        CXXFLAGS: '/arch:IA32'
       XP_x64:
         gtk-bundle: 'http://ftp.gnome.org/pub/gnome/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip'
         libsndfile-url: 'http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.28-w64.zip'


### PR DESCRIPTION
Simplify Windows pipeline and make sure to compile XP x86 binaries for x87 FPU only.