### PR TITLE
Fix warning from libinstpatch-scan.c (gtkdoc)

### DIFF
--- a/docs/reference/CMakeLists.txt
+++ b/docs/reference/CMakeLists.txt
@@ -36,7 +36,7 @@ if (GTKDOC_FOUND)
     IGNOREHEADERS ${ignore_headers}
     SCANOPTS ${CMAKE_CURRENT_BINARY_DIR}/../../libinstpatch/version.h
     SCANOBJOPTS --type-init-func=ipatch_init\(\)
-    CFLAGS -I${CMAKE_SOURCE_DIR}
+    CFLAGS -I${CMAKE_SOURCE_DIR} -include libinstpatch/misc.h
     LDFLAGS -L${CMAKE_CURRENT_BINARY_DIR}/../../libinstpatch -linstpatch-1.0
     LDPATH ${CMAKE_CURRENT_BINARY_DIR}/../../libinstpatch
     DEPENDS instpatch-1.0


### PR DESCRIPTION
Fixes warning ”`implicit declaration of function ‘ipatch_init’`” mentioned in https://github.com/swami/libinstpatch/issues/65. This warning could be an error in some C99 and later environments.

Using the `-include` GCC-compatible option to forcibly include the necessary header is a little hacky, but I don’t know a way to add `#include "libinstpatch/misc.h"` to the source of the temporary generated C program directly.