### PR TITLE
Eliminate CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,9 @@
 # See COPYING license file for distribution details
 #
 
+cmake_minimum_required ( VERSION 3.6 )
 project ( libInstPatch C )
-cmake_minimum_required ( VERSION 3.0 )
+
 set ( CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
 
 # libInstPatch package name


### PR DESCRIPTION
Here are the warnings in CMake:

```
CMake Warning (dev) at CMakeLists.txt:9 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Deprecation Warning at CMakeLists.txt:10 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Modify `CMakeLists.txt` to eliminate.