### PR TITLE
Remove sndfile.h from public headers

### DIFF
--- a/libinstpatch/IpatchSampleStoreSndFile.c
+++ b/libinstpatch/IpatchSampleStoreSndFile.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <glib.h>
 #include <glib-object.h>
+#include <sndfile.h>
 
 #include "IpatchSampleStoreSndFile.h"
 #include "IpatchSampleStore.h"

--- a/libinstpatch/IpatchSampleStoreSndFile.h
+++ b/libinstpatch/IpatchSampleStoreSndFile.h
@@ -24,8 +24,6 @@
 #include <glib-object.h>
 #include <libinstpatch/IpatchSampleStore.h>
 
-#include <sndfile.h>
-
 /* forward type declarations */
 
 typedef struct _IpatchSampleStoreSndFile IpatchSampleStoreSndFile;

--- a/libinstpatch/IpatchSndFile.h
+++ b/libinstpatch/IpatchSndFile.h
@@ -24,8 +24,6 @@
 #include <glib-object.h>
 #include <libinstpatch/IpatchFile.h>
 
-#include <sndfile.h>
-
 typedef struct _IpatchSndFile IpatchSndFile;
 typedef struct _IpatchSndFileClass IpatchSndFileClass;
 


### PR DESCRIPTION
Exposing `sndfile.h` in public headers forces depending apps (like fluidsynth) to have libsndfile available at compile time. This breaks the build if e.g. libsndfile is indeed available when building fluidsynth, but fluidsynth rejects it because its version is insufficient.