### PR TITLE
Update LGPLv2.1 license text and notices for remote-only FSF

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -5,7 +5,7 @@ NOTE: This software is restricted to version 2.1 of the LGPL only.
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
-	51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -25,8 +25,7 @@ specially designated software packages--typically libraries--of the
 Free Software Foundation and other authors who decide to use it.  You
 can use it too, but we suggest you first think carefully about whether
 this license or the ordinary General Public License is the better
-strategy to use in any particular case, based on the explanations
-below.
+strategy to use in any particular case, based on the explanations below.
 
   When we speak of free software, we are referring to freedom of use,
 not price.  Our General Public Licenses are designed to make sure that
@@ -91,9 +90,9 @@ libraries.  However, the Lesser license provides advantages in certain
 special circumstances.
 
   For example, on rare occasions, there may be a special need to
-encourage the widest possible use of a certain library, so that it
-becomes a de-facto standard.  To achieve this, non-free programs must
-be allowed to use the library.  A more frequent case is that a free
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
 library does the same job as widely used non-free libraries.  In this
 case, there is little to gain by limiting the free library to free
 software only, so we use the Lesser General Public License.
@@ -140,8 +139,8 @@ included without limitation in the term "modification".)
   "Source code" for a work means the preferred form of the work for
 making modifications to it.  For a library, complete source code means
 all the source code for all modules it contains, plus any associated
-interface definition files, plus the scripts used to control
-compilation and installation of the library.
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
 
   Activities other than copying, distribution and modification are not
 covered by this License; they are outside its scope.  The act of
@@ -307,10 +306,10 @@ of these things:
     the user installs one, as long as the modified version is
     interface-compatible with the version that the work was made with.
 
-    c) Accompany the work with a written offer, valid for at least
-    three years, to give the same user the materials specified in
-    Subsection 6a, above, for a charge no more than the cost of
-    performing this distribution.
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
 
     d) If distribution of the work is made by offering access to copy
     from a designated place, offer equivalent access to copy the above
@@ -388,10 +387,9 @@ all those who receive copies directly or indirectly through you, then
 the only way you could satisfy both it and this License would be to
 refrain entirely from distribution of the Library.
 
-If any portion of this section is held invalid or unenforceable under
-any particular circumstance, the balance of the section is intended to
-apply, and the section as a whole is intended to apply in other
-circumstances.
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
 
 It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
@@ -409,11 +407,11 @@ be a consequence of the rest of this License.
 
   12. If the distribution and/or use of the Library is restricted in
 certain countries either by patents or by copyrighted interfaces, the
-original copyright holder who places the Library under this License
-may add an explicit geographical distribution limitation excluding those
-countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
-the limitation as if written in the body of this License.
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
 
   13. The Free Software Foundation may publish revised and/or new
 versions of the Lesser General Public License from time to time.
@@ -461,4 +459,3 @@ SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGES.
 
                      END OF TERMS AND CONDITIONS
-

--- a/libinstpatch/IpatchBase.c
+++ b/libinstpatch/IpatchBase.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchBase

--- a/libinstpatch/IpatchBase.h
+++ b/libinstpatch/IpatchBase.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  *
  */
 #ifndef __IPATCH_BASE_H__

--- a/libinstpatch/IpatchContainer.c
+++ b/libinstpatch/IpatchContainer.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchContainer

--- a/libinstpatch/IpatchContainer.h
+++ b/libinstpatch/IpatchContainer.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONTAINER_H__
 #define __IPATCH_CONTAINER_H__

--- a/libinstpatch/IpatchContainer_notify.c
+++ b/libinstpatch/IpatchContainer_notify.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * IpatchContainer_notify.c - Container add/remove callback notify system

--- a/libinstpatch/IpatchConvert_DLS2.c
+++ b/libinstpatch/IpatchConvert_DLS2.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchConvert_DLS2

--- a/libinstpatch/IpatchConvert_DLS2.h
+++ b/libinstpatch/IpatchConvert_DLS2.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONVERT_DLS2_H__
 #define __IPATCH_CONVERT_DLS2_H__

--- a/libinstpatch/IpatchConvert_Gig.c
+++ b/libinstpatch/IpatchConvert_Gig.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchConvert_Gig

--- a/libinstpatch/IpatchConvert_Gig.h
+++ b/libinstpatch/IpatchConvert_Gig.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONVERT_GIG_H__
 #define __IPATCH_CONVERT_GIG_H__

--- a/libinstpatch/IpatchConvert_SF2.c
+++ b/libinstpatch/IpatchConvert_SF2.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchConvert_SF2

--- a/libinstpatch/IpatchConvert_SF2.h
+++ b/libinstpatch/IpatchConvert_SF2.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONVERT_SF2_H__
 #define __IPATCH_CONVERT_SF2_H__

--- a/libinstpatch/IpatchConvert_SLI.c
+++ b/libinstpatch/IpatchConvert_SLI.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchConvert_SLI

--- a/libinstpatch/IpatchConvert_SLI.h
+++ b/libinstpatch/IpatchConvert_SLI.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONVERT_SLI_H__
 #define __IPATCH_CONVERT_SLI_H__

--- a/libinstpatch/IpatchConverter.c
+++ b/libinstpatch/IpatchConverter.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchConverter

--- a/libinstpatch/IpatchConverter.h
+++ b/libinstpatch/IpatchConverter.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONVERTER_H__
 #define __IPATCH_CONVERTER_H__

--- a/libinstpatch/IpatchConverterSF2VoiceCache.c
+++ b/libinstpatch/IpatchConverterSF2VoiceCache.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchConverterSF2VoiceCache

--- a/libinstpatch/IpatchConverterSF2VoiceCache.h
+++ b/libinstpatch/IpatchConverterSF2VoiceCache.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_CONVERTER_SF2_VOICE_CACHE_H__
 #define __IPATCH_CONVERTER_SF2_VOICE_CACHE_H__

--- a/libinstpatch/IpatchConverter_priv.h
+++ b/libinstpatch/IpatchConverter_priv.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * IpatchConverter_priv.h - Helper macros for defining converters

--- a/libinstpatch/IpatchDLS2.c
+++ b/libinstpatch/IpatchDLS2.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLS2

--- a/libinstpatch/IpatchDLS2.h
+++ b/libinstpatch/IpatchDLS2.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS2_H__
 #define __IPATCH_DLS2_H__

--- a/libinstpatch/IpatchDLS2Conn.c
+++ b/libinstpatch/IpatchDLS2Conn.c
@@ -13,9 +13,7 @@
  * GNU Conneral Public License for more details.
  *
  * You should have received a copy of the GNU Conneral Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLS2Conn

--- a/libinstpatch/IpatchDLS2Conn.h
+++ b/libinstpatch/IpatchDLS2Conn.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS2_CONN_H__
 #define __IPATCH_DLS2_CONN_H__

--- a/libinstpatch/IpatchDLS2Info.c
+++ b/libinstpatch/IpatchDLS2Info.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLS2Info

--- a/libinstpatch/IpatchDLS2Info.h
+++ b/libinstpatch/IpatchDLS2Info.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS2_INFO_H__
 #define __IPATCH_DLS2_INFO_H__

--- a/libinstpatch/IpatchDLS2Inst.c
+++ b/libinstpatch/IpatchDLS2Inst.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLS2Inst

--- a/libinstpatch/IpatchDLS2Inst.h
+++ b/libinstpatch/IpatchDLS2Inst.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS2_INST_H__
 #define __IPATCH_DLS2_INST_H__

--- a/libinstpatch/IpatchDLS2Region.c
+++ b/libinstpatch/IpatchDLS2Region.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLS2Region

--- a/libinstpatch/IpatchDLS2Region.h
+++ b/libinstpatch/IpatchDLS2Region.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS2_REGION_H__
 #define __IPATCH_DLS2_REGION_H__

--- a/libinstpatch/IpatchDLS2Sample.c
+++ b/libinstpatch/IpatchDLS2Sample.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLS2Sample

--- a/libinstpatch/IpatchDLS2Sample.h
+++ b/libinstpatch/IpatchDLS2Sample.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS2_SAMPLE_H__
 #define __IPATCH_DLS2_SAMPLE_H__

--- a/libinstpatch/IpatchDLSFile.c
+++ b/libinstpatch/IpatchDLSFile.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLSFile

--- a/libinstpatch/IpatchDLSFile.h
+++ b/libinstpatch/IpatchDLSFile.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS_FILE_H__
 #define __IPATCH_DLS_FILE_H__

--- a/libinstpatch/IpatchDLSFile_priv.h
+++ b/libinstpatch/IpatchDLSFile_priv.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS_FILE_PRIV_H__
 #define __IPATCH_DLS_FILE_PRIV_H__

--- a/libinstpatch/IpatchDLSReader.c
+++ b/libinstpatch/IpatchDLSReader.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLSReader

--- a/libinstpatch/IpatchDLSReader.h
+++ b/libinstpatch/IpatchDLSReader.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS_READER_H__
 #define __IPATCH_DLS_READER_H__

--- a/libinstpatch/IpatchDLSWriter.c
+++ b/libinstpatch/IpatchDLSWriter.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchDLSWriter

--- a/libinstpatch/IpatchDLSWriter.h
+++ b/libinstpatch/IpatchDLSWriter.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_DLS_WRITER_H__
 #define __IPATCH_DLS_WRITER_H__

--- a/libinstpatch/IpatchFile.c
+++ b/libinstpatch/IpatchFile.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchFile

--- a/libinstpatch/IpatchFile.h
+++ b/libinstpatch/IpatchFile.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_FILE_H__
 #define __IPATCH_FILE_H__

--- a/libinstpatch/IpatchFileBuf.c
+++ b/libinstpatch/IpatchFileBuf.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * IpatchFile.c - File buffer and integer read/write funcs

--- a/libinstpatch/IpatchGig.c
+++ b/libinstpatch/IpatchGig.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGig

--- a/libinstpatch/IpatchGig.h
+++ b/libinstpatch/IpatchGig.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_H__
 #define __IPATCH_GIG_H__

--- a/libinstpatch/IpatchGigDimension.c
+++ b/libinstpatch/IpatchGigDimension.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigDimension

--- a/libinstpatch/IpatchGigDimension.h
+++ b/libinstpatch/IpatchGigDimension.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_DIMENSION_H__
 #define __IPATCH_GIG_DIMENSION_H__

--- a/libinstpatch/IpatchGigEffects.c
+++ b/libinstpatch/IpatchGigEffects.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigEffects

--- a/libinstpatch/IpatchGigEffects.h
+++ b/libinstpatch/IpatchGigEffects.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_EFFECTS_H__
 #define __IPATCH_GIG_EFFECTS_H__

--- a/libinstpatch/IpatchGigFile.c
+++ b/libinstpatch/IpatchGigFile.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigFile

--- a/libinstpatch/IpatchGigFile.h
+++ b/libinstpatch/IpatchGigFile.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_FILE_H__
 #define __IPATCH_GIG_FILE_H__

--- a/libinstpatch/IpatchGigFile_priv.h
+++ b/libinstpatch/IpatchGigFile_priv.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_FILE_PRIV_H__
 #define __IPATCH_GIG_FILE_PRIV_H__

--- a/libinstpatch/IpatchGigInst.c
+++ b/libinstpatch/IpatchGigInst.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigInst

--- a/libinstpatch/IpatchGigInst.h
+++ b/libinstpatch/IpatchGigInst.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_INST_H__
 #define __IPATCH_GIG_INST_H__

--- a/libinstpatch/IpatchGigRegion.c
+++ b/libinstpatch/IpatchGigRegion.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigRegion

--- a/libinstpatch/IpatchGigRegion.h
+++ b/libinstpatch/IpatchGigRegion.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_REGION_H__
 #define __IPATCH_GIG_REGION_H__

--- a/libinstpatch/IpatchGigSample.c
+++ b/libinstpatch/IpatchGigSample.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigSample

--- a/libinstpatch/IpatchGigSample.h
+++ b/libinstpatch/IpatchGigSample.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_SAMPLE_H__
 #define __IPATCH_GIG_SAMPLE_H__

--- a/libinstpatch/IpatchGigSubRegion.c
+++ b/libinstpatch/IpatchGigSubRegion.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchGigSubRegion

--- a/libinstpatch/IpatchGigSubRegion.h
+++ b/libinstpatch/IpatchGigSubRegion.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_GIG_SUB_REGION_H__
 #define __IPATCH_GIG_SUB_REGION_H__

--- a/libinstpatch/IpatchItem.c
+++ b/libinstpatch/IpatchItem.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchItem

--- a/libinstpatch/IpatchItem.h
+++ b/libinstpatch/IpatchItem.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_ITEM_H__
 #define __IPATCH_ITEM_H__

--- a/libinstpatch/IpatchItemProp.c
+++ b/libinstpatch/IpatchItemProp.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * IpatchItemProp.c - IpatchItem property change callback system

--- a/libinstpatch/IpatchIter.c
+++ b/libinstpatch/IpatchIter.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchIter

--- a/libinstpatch/IpatchIter.h
+++ b/libinstpatch/IpatchIter.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_ITER_H__
 #define __IPATCH_ITER_H__

--- a/libinstpatch/IpatchList.c
+++ b/libinstpatch/IpatchList.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchList

--- a/libinstpatch/IpatchList.h
+++ b/libinstpatch/IpatchList.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_LIST_H__
 #define __IPATCH_LIST_H__

--- a/libinstpatch/IpatchParamProp.c
+++ b/libinstpatch/IpatchParamProp.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchParamProp

--- a/libinstpatch/IpatchParamProp.h
+++ b/libinstpatch/IpatchParamProp.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_PARAM_PROP_H__
 #define __IPATCH_PARAM_PROP_H__

--- a/libinstpatch/IpatchPaste.c
+++ b/libinstpatch/IpatchPaste.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchPaste

--- a/libinstpatch/IpatchPaste.h
+++ b/libinstpatch/IpatchPaste.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_PASTE_H__
 #define __IPATCH_PASTE_H__

--- a/libinstpatch/IpatchRange.c
+++ b/libinstpatch/IpatchRange.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchRange

--- a/libinstpatch/IpatchRange.h
+++ b/libinstpatch/IpatchRange.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_RANGE_H__
 #define __IPATCH_RANGE_H__

--- a/libinstpatch/IpatchRiff.c
+++ b/libinstpatch/IpatchRiff.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchRiff

--- a/libinstpatch/IpatchRiff.h
+++ b/libinstpatch/IpatchRiff.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_RIFF_H__
 #define __IPATCH_RIFF_H__

--- a/libinstpatch/IpatchSF2.c
+++ b/libinstpatch/IpatchSF2.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2

--- a/libinstpatch/IpatchSF2.h
+++ b/libinstpatch/IpatchSF2.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_H__
 #define __IPATCH_SF2_H__

--- a/libinstpatch/IpatchSF2File.c
+++ b/libinstpatch/IpatchSF2File.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2File

--- a/libinstpatch/IpatchSF2File.h
+++ b/libinstpatch/IpatchSF2File.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_FILE_H__
 #define __IPATCH_SF2_FILE_H__

--- a/libinstpatch/IpatchSF2File_priv.h
+++ b/libinstpatch/IpatchSF2File_priv.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_FILE_PRIV_H__
 #define __IPATCH_SF2_FILE_PRIV_H__

--- a/libinstpatch/IpatchSF2Gen.c
+++ b/libinstpatch/IpatchSF2Gen.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Gen

--- a/libinstpatch/IpatchSF2Gen.h
+++ b/libinstpatch/IpatchSF2Gen.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_GEN_H__
 #define __IPATCH_SF2_GEN_H__

--- a/libinstpatch/IpatchSF2GenItem.c
+++ b/libinstpatch/IpatchSF2GenItem.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2GenItem

--- a/libinstpatch/IpatchSF2GenItem.h
+++ b/libinstpatch/IpatchSF2GenItem.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_GEN_ITEM_H__
 #define __IPATCH_SF2_GEN_ITEM_H__

--- a/libinstpatch/IpatchSF2Gen_tables.c
+++ b/libinstpatch/IpatchSF2Gen_tables.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * IpatchSF2Gen_tables.c - SoundFont generator table structures

--- a/libinstpatch/IpatchSF2IZone.c
+++ b/libinstpatch/IpatchSF2IZone.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2IZone

--- a/libinstpatch/IpatchSF2IZone.h
+++ b/libinstpatch/IpatchSF2IZone.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_IZONE_H__
 #define __IPATCH_SF2_IZONE_H__

--- a/libinstpatch/IpatchSF2Inst.c
+++ b/libinstpatch/IpatchSF2Inst.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Inst

--- a/libinstpatch/IpatchSF2Inst.h
+++ b/libinstpatch/IpatchSF2Inst.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_INST_H__
 #define __IPATCH_SF2_INST_H__

--- a/libinstpatch/IpatchSF2Mod.c
+++ b/libinstpatch/IpatchSF2Mod.c
@@ -13,9 +13,7 @@
  * GNU Moderal Public License for more details.
  *
  * You should have received a copy of the GNU Moderal Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Mod

--- a/libinstpatch/IpatchSF2Mod.h
+++ b/libinstpatch/IpatchSF2Mod.h
@@ -13,9 +13,7 @@
  * GNU Moderal Public License for more details.
  *
  * You should have received a copy of the GNU Moderal Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_MOD_H__
 #define __IPATCH_SF2_MOD_H__

--- a/libinstpatch/IpatchSF2ModItem.c
+++ b/libinstpatch/IpatchSF2ModItem.c
@@ -13,9 +13,7 @@
  * GNU Moderal Public License for more details.
  *
  * You should have received a copy of the GNU Moderal Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2ModItem

--- a/libinstpatch/IpatchSF2ModItem.h
+++ b/libinstpatch/IpatchSF2ModItem.h
@@ -13,9 +13,7 @@
  * GNU Moderal Public License for more details.
  *
  * You should have received a copy of the GNU Moderal Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_MOD_ITEM_H__
 #define __IPATCH_SF2_MOD_ITEM_H__

--- a/libinstpatch/IpatchSF2ModList.c
+++ b/libinstpatch/IpatchSF2ModList.c
@@ -13,9 +13,7 @@
  * GNU Moderal Public License for more details.
  *
  * You should have received a copy of the GNU Moderal Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2ModList

--- a/libinstpatch/IpatchSF2ModList.h
+++ b/libinstpatch/IpatchSF2ModList.h
@@ -13,9 +13,7 @@
  * GNU Moderal Public License for more details.
  *
  * You should have received a copy of the GNU Moderal Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_MOD_LIST_H__
 #define __IPATCH_SF2_MOD_LIST_H__

--- a/libinstpatch/IpatchSF2PZone.c
+++ b/libinstpatch/IpatchSF2PZone.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2PZone

--- a/libinstpatch/IpatchSF2PZone.h
+++ b/libinstpatch/IpatchSF2PZone.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_PZONE_H__
 #define __IPATCH_SF2_PZONE_H__

--- a/libinstpatch/IpatchSF2Preset.c
+++ b/libinstpatch/IpatchSF2Preset.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Preset

--- a/libinstpatch/IpatchSF2Preset.h
+++ b/libinstpatch/IpatchSF2Preset.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_PRESET_H__
 #define __IPATCH_SF2_PRESET_H__

--- a/libinstpatch/IpatchSF2Reader.c
+++ b/libinstpatch/IpatchSF2Reader.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Reader

--- a/libinstpatch/IpatchSF2Reader.h
+++ b/libinstpatch/IpatchSF2Reader.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_READER_H__
 #define __IPATCH_SF2_READER_H__

--- a/libinstpatch/IpatchSF2Sample.c
+++ b/libinstpatch/IpatchSF2Sample.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Sample

--- a/libinstpatch/IpatchSF2Sample.h
+++ b/libinstpatch/IpatchSF2Sample.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_SAMPLE_H__
 #define __IPATCH_SF2_SAMPLE_H__

--- a/libinstpatch/IpatchSF2VoiceCache.c
+++ b/libinstpatch/IpatchSF2VoiceCache.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2VoiceCache

--- a/libinstpatch/IpatchSF2VoiceCache.h
+++ b/libinstpatch/IpatchSF2VoiceCache.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_VOICE_CACHE_H__
 #define __IPATCH_SF2_VOICE_CACHE_H__

--- a/libinstpatch/IpatchSF2VoiceCache_DLS.c
+++ b/libinstpatch/IpatchSF2VoiceCache_DLS.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <string.h>

--- a/libinstpatch/IpatchSF2VoiceCache_DLS.h
+++ b/libinstpatch/IpatchSF2VoiceCache_DLS.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_VOICE_CACHE_DLS_H__
 #define __IPATCH_SF2_VOICE_CACHE_DLS_H__

--- a/libinstpatch/IpatchSF2VoiceCache_Gig.c
+++ b/libinstpatch/IpatchSF2VoiceCache_Gig.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2VoiceCache_Gig

--- a/libinstpatch/IpatchSF2VoiceCache_Gig.h
+++ b/libinstpatch/IpatchSF2VoiceCache_Gig.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_VOICE_CACHE_GIG_H__
 #define __IPATCH_SF2_VOICE_CACHE_GIG_H__

--- a/libinstpatch/IpatchSF2VoiceCache_SF2.c
+++ b/libinstpatch/IpatchSF2VoiceCache_SF2.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <string.h>

--- a/libinstpatch/IpatchSF2VoiceCache_SF2.h
+++ b/libinstpatch/IpatchSF2VoiceCache_SF2.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  *
  */
 #ifndef __IPATCH_SF2_VOICE_CACHE_SF2_H__

--- a/libinstpatch/IpatchSF2VoiceCache_SLI.c
+++ b/libinstpatch/IpatchSF2VoiceCache_SLI.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <string.h>

--- a/libinstpatch/IpatchSF2VoiceCache_SLI.h
+++ b/libinstpatch/IpatchSF2VoiceCache_SLI.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_VOICE_CACHE_SLI_H__
 #define __IPATCH_SF2_VOICE_CACHE_SLI_H__

--- a/libinstpatch/IpatchSF2VoiceCache_VBank.c
+++ b/libinstpatch/IpatchSF2VoiceCache_VBank.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2VoiceCache_VBank

--- a/libinstpatch/IpatchSF2VoiceCache_VBank.h
+++ b/libinstpatch/IpatchSF2VoiceCache_VBank.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_VOICE_CACHE_VBANK_H__
 #define __IPATCH_SF2_VOICE_CACHE_VBANK_H__

--- a/libinstpatch/IpatchSF2Writer.c
+++ b/libinstpatch/IpatchSF2Writer.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Writer

--- a/libinstpatch/IpatchSF2Writer.h
+++ b/libinstpatch/IpatchSF2Writer.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_WRITER_H__
 #define __IPATCH_SF2_WRITER_H__

--- a/libinstpatch/IpatchSF2Zone.c
+++ b/libinstpatch/IpatchSF2Zone.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSF2Zone

--- a/libinstpatch/IpatchSF2Zone.h
+++ b/libinstpatch/IpatchSF2Zone.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SF2_ZONE_H__
 #define __IPATCH_SF2_ZONE_H__

--- a/libinstpatch/IpatchSLI.c
+++ b/libinstpatch/IpatchSLI.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLI

--- a/libinstpatch/IpatchSLI.h
+++ b/libinstpatch/IpatchSLI.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_H__
 #define __IPATCH_SLI_H__

--- a/libinstpatch/IpatchSLIFile.c
+++ b/libinstpatch/IpatchSLIFile.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLIFile

--- a/libinstpatch/IpatchSLIFile.h
+++ b/libinstpatch/IpatchSLIFile.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_FILE_H__
 #define __IPATCH_SLI_FILE_H__

--- a/libinstpatch/IpatchSLIFile_priv.h
+++ b/libinstpatch/IpatchSLIFile_priv.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_FILE_PRIV_H__
 #define __IPATCH_SLI_FILE_PRIV_H__

--- a/libinstpatch/IpatchSLIInst.c
+++ b/libinstpatch/IpatchSLIInst.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLIInst

--- a/libinstpatch/IpatchSLIInst.h
+++ b/libinstpatch/IpatchSLIInst.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_INST_H__
 #define __IPATCH_SLI_INST_H__

--- a/libinstpatch/IpatchSLIInst_CatMaps.c
+++ b/libinstpatch/IpatchSLIInst_CatMaps.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "IpatchSLIInst.h"

--- a/libinstpatch/IpatchSLIReader.c
+++ b/libinstpatch/IpatchSLIReader.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLIReader

--- a/libinstpatch/IpatchSLIReader.h
+++ b/libinstpatch/IpatchSLIReader.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_READER_H__
 #define __IPATCH_SLI_READER_H__

--- a/libinstpatch/IpatchSLISample.c
+++ b/libinstpatch/IpatchSLISample.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLISample

--- a/libinstpatch/IpatchSLISample.h
+++ b/libinstpatch/IpatchSLISample.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_SAMPLE_H__
 #define __IPATCH_SLI_SAMPLE_H__

--- a/libinstpatch/IpatchSLIWriter.c
+++ b/libinstpatch/IpatchSLIWriter.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLIWriter

--- a/libinstpatch/IpatchSLIWriter.h
+++ b/libinstpatch/IpatchSLIWriter.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_WRITER_H__
 #define __IPATCH_SLI_WRITER_H__

--- a/libinstpatch/IpatchSLIZone.c
+++ b/libinstpatch/IpatchSLIZone.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSLIZone

--- a/libinstpatch/IpatchSLIZone.h
+++ b/libinstpatch/IpatchSLIZone.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SLI_ZONE_H__
 #define __IPATCH_SLI_ZONE_H__

--- a/libinstpatch/IpatchSample.c
+++ b/libinstpatch/IpatchSample.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSample

--- a/libinstpatch/IpatchSample.h
+++ b/libinstpatch/IpatchSample.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_H__
 #define __IPATCH_SAMPLE_H__

--- a/libinstpatch/IpatchSampleData.c
+++ b/libinstpatch/IpatchSampleData.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleData

--- a/libinstpatch/IpatchSampleData.h
+++ b/libinstpatch/IpatchSampleData.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_DATA_H__
 #define __IPATCH_SAMPLE_DATA_H__

--- a/libinstpatch/IpatchSampleList.c
+++ b/libinstpatch/IpatchSampleList.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleList

--- a/libinstpatch/IpatchSampleList.h
+++ b/libinstpatch/IpatchSampleList.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_LIST_H__
 #define __IPATCH_SAMPLE_LIST_H__

--- a/libinstpatch/IpatchSampleStore.c
+++ b/libinstpatch/IpatchSampleStore.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStore

--- a/libinstpatch/IpatchSampleStore.h
+++ b/libinstpatch/IpatchSampleStore.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_H__
 #define __IPATCH_SAMPLE_STORE_H__

--- a/libinstpatch/IpatchSampleStoreCache.c
+++ b/libinstpatch/IpatchSampleStoreCache.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreCache

--- a/libinstpatch/IpatchSampleStoreCache.h
+++ b/libinstpatch/IpatchSampleStoreCache.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_CACHE_H__
 #define __IPATCH_SAMPLE_STORE_CACHE_H__

--- a/libinstpatch/IpatchSampleStoreFile.c
+++ b/libinstpatch/IpatchSampleStoreFile.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreFile

--- a/libinstpatch/IpatchSampleStoreFile.h
+++ b/libinstpatch/IpatchSampleStoreFile.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_FILE_H__
 #define __IPATCH_SAMPLE_STORE_FILE_H__

--- a/libinstpatch/IpatchSampleStoreRam.c
+++ b/libinstpatch/IpatchSampleStoreRam.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreRam

--- a/libinstpatch/IpatchSampleStoreRam.h
+++ b/libinstpatch/IpatchSampleStoreRam.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_RAM_H__
 #define __IPATCH_SAMPLE_STORE_RAM_H__

--- a/libinstpatch/IpatchSampleStoreRom.c
+++ b/libinstpatch/IpatchSampleStoreRom.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreRom

--- a/libinstpatch/IpatchSampleStoreRom.h
+++ b/libinstpatch/IpatchSampleStoreRom.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_ROM_H__
 #define __IPATCH_SAMPLE_STORE_ROM_H__

--- a/libinstpatch/IpatchSampleStoreSndFile.c
+++ b/libinstpatch/IpatchSampleStoreSndFile.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreSndFile

--- a/libinstpatch/IpatchSampleStoreSndFile.h
+++ b/libinstpatch/IpatchSampleStoreSndFile.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_SND_FILE_H__
 #define __IPATCH_SAMPLE_STORE_SND_FILE_H__

--- a/libinstpatch/IpatchSampleStoreSplit24.c
+++ b/libinstpatch/IpatchSampleStoreSplit24.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreSplit24

--- a/libinstpatch/IpatchSampleStoreSplit24.h
+++ b/libinstpatch/IpatchSampleStoreSplit24.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_SPLIT24_H__
 #define __IPATCH_SAMPLE_STORE_SPLIT24_H__

--- a/libinstpatch/IpatchSampleStoreSwap.c
+++ b/libinstpatch/IpatchSampleStoreSwap.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreSwap

--- a/libinstpatch/IpatchSampleStoreSwap.h
+++ b/libinstpatch/IpatchSampleStoreSwap.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_SWAP_H__
 #define __IPATCH_SAMPLE_STORE_SWAP_H__

--- a/libinstpatch/IpatchSampleStoreVirtual.c
+++ b/libinstpatch/IpatchSampleStoreVirtual.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleStoreVirtual

--- a/libinstpatch/IpatchSampleStoreVirtual.h
+++ b/libinstpatch/IpatchSampleStoreVirtual.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_STORE_VIRTUAL_H__
 #define __IPATCH_SAMPLE_STORE_VIRTUAL_H__

--- a/libinstpatch/IpatchSampleTransform.c
+++ b/libinstpatch/IpatchSampleTransform.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSampleTransform

--- a/libinstpatch/IpatchSampleTransform.h
+++ b/libinstpatch/IpatchSampleTransform.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SAMPLE_TRANSFORM_H__
 #define __IPATCH_SAMPLE_TRANSFORM_H__

--- a/libinstpatch/IpatchSndFile.c
+++ b/libinstpatch/IpatchSndFile.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchSndFile

--- a/libinstpatch/IpatchSndFile.h
+++ b/libinstpatch/IpatchSndFile.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_SND_FILE_H__
 #define __IPATCH_SND_FILE_H__

--- a/libinstpatch/IpatchState.c
+++ b/libinstpatch/IpatchState.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <glib.h>

--- a/libinstpatch/IpatchState.h
+++ b/libinstpatch/IpatchState.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_STATE_H__
 #define __IPATCH_STATE_H__

--- a/libinstpatch/IpatchStateGroup.c
+++ b/libinstpatch/IpatchStateGroup.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <glib.h>

--- a/libinstpatch/IpatchStateGroup.h
+++ b/libinstpatch/IpatchStateGroup.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_STATE_GROUP_H__
 #define __IPATCH_STATE_GROUP_H__

--- a/libinstpatch/IpatchStateItem.c
+++ b/libinstpatch/IpatchStateItem.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <glib.h>

--- a/libinstpatch/IpatchStateItem.h
+++ b/libinstpatch/IpatchStateItem.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_STATE_ITEM_H__
 #define __IPATCH_STATE_ITEM_H__

--- a/libinstpatch/IpatchState_types.c
+++ b/libinstpatch/IpatchState_types.c
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <stdio.h>
 #include <string.h>

--- a/libinstpatch/IpatchState_types.h
+++ b/libinstpatch/IpatchState_types.h
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_STATE_TYPES_H__
 #define __IPATCH_STATE_TYPES_H__

--- a/libinstpatch/IpatchTypeProp.c
+++ b/libinstpatch/IpatchTypeProp.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchTypeProp

--- a/libinstpatch/IpatchTypeProp.h
+++ b/libinstpatch/IpatchTypeProp.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_TYPE_PROP_H__
 #define __IPATCH_TYPE_PROP_H__

--- a/libinstpatch/IpatchUnit.c
+++ b/libinstpatch/IpatchUnit.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchUnit

--- a/libinstpatch/IpatchUnit.h
+++ b/libinstpatch/IpatchUnit.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_UNIT_H__
 #define __IPATCH_UNIT_H__

--- a/libinstpatch/IpatchUnit_DLS.c
+++ b/libinstpatch/IpatchUnit_DLS.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchUnit_DLS

--- a/libinstpatch/IpatchUnit_DLS.h
+++ b/libinstpatch/IpatchUnit_DLS.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_UNIT_DLS_H__
 #define __IPATCH_UNIT_DLS_H__

--- a/libinstpatch/IpatchUnit_SF2.c
+++ b/libinstpatch/IpatchUnit_SF2.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchUnit_SF2

--- a/libinstpatch/IpatchUnit_SF2.h
+++ b/libinstpatch/IpatchUnit_SF2.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_UNIT_SF2_H__
 #define __IPATCH_UNIT_SF2_H__

--- a/libinstpatch/IpatchUnit_generic.c
+++ b/libinstpatch/IpatchUnit_generic.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchUnit_generic

--- a/libinstpatch/IpatchUnit_generic.h
+++ b/libinstpatch/IpatchUnit_generic.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_UNIT_GENERIC_H__
 #define __IPATCH_UNIT_GENERIC_H__

--- a/libinstpatch/IpatchVBank.c
+++ b/libinstpatch/IpatchVBank.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchVBank

--- a/libinstpatch/IpatchVBank.h
+++ b/libinstpatch/IpatchVBank.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_VBANK_H__
 #define __IPATCH_VBANK_H__

--- a/libinstpatch/IpatchVBankInst.c
+++ b/libinstpatch/IpatchVBankInst.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchVBankInst

--- a/libinstpatch/IpatchVBankInst.h
+++ b/libinstpatch/IpatchVBankInst.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_VBANK_INST_H__
 #define __IPATCH_VBANK_INST_H__

--- a/libinstpatch/IpatchVBankRegion.c
+++ b/libinstpatch/IpatchVBankRegion.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchVBankRegion

--- a/libinstpatch/IpatchVBankRegion.h
+++ b/libinstpatch/IpatchVBankRegion.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_VBANK_REGION_H__
 #define __IPATCH_VBANK_REGION_H__

--- a/libinstpatch/IpatchVirtualContainer.c
+++ b/libinstpatch/IpatchVirtualContainer.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchVirtualContainer

--- a/libinstpatch/IpatchVirtualContainer.h
+++ b/libinstpatch/IpatchVirtualContainer.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_VIRTUAL_CONTAINER_H__
 #define __IPATCH_VIRTUAL_CONTAINER_H__

--- a/libinstpatch/IpatchVirtualContainer_types.c
+++ b/libinstpatch/IpatchVirtualContainer_types.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchVirtualContainer_types

--- a/libinstpatch/IpatchVirtualContainer_types.h
+++ b/libinstpatch/IpatchVirtualContainer_types.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_VIRTUAL_CONTAINER_TYPES_H__
 #define __IPATCH_VIRTUAL_CONTAINER_TYPES_H__

--- a/libinstpatch/IpatchXml.c
+++ b/libinstpatch/IpatchXml.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchXml

--- a/libinstpatch/IpatchXml.h
+++ b/libinstpatch/IpatchXml.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_XML_H__
 #define __IPATCH_XML_H__

--- a/libinstpatch/IpatchXmlObject.c
+++ b/libinstpatch/IpatchXmlObject.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: IpatchXmlObject

--- a/libinstpatch/IpatchXmlObject.h
+++ b/libinstpatch/IpatchXmlObject.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_XML_OBJECT_H__
 #define __IPATCH_XML_OBJECT_H__

--- a/libinstpatch/compat.c
+++ b/libinstpatch/compat.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include "compat.h"
 

--- a/libinstpatch/compat.h
+++ b/libinstpatch/compat.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /* Older glib compatibility functions */
 

--- a/libinstpatch/ipatch_priv.h
+++ b/libinstpatch/ipatch_priv.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /*
  * ipatch_priv.h - Private header file

--- a/libinstpatch/libinstpatch.h.in
+++ b/libinstpatch/libinstpatch.h.in
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __LIB_INST_PATCH_H__
 #define __LIB_INST_PATCH_H__

--- a/libinstpatch/misc.c
+++ b/libinstpatch/misc.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: misc

--- a/libinstpatch/misc.h
+++ b/libinstpatch/misc.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __MISC_H__
 #define __MISC_H__

--- a/libinstpatch/sample.c
+++ b/libinstpatch/sample.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: sample

--- a/libinstpatch/sample.h
+++ b/libinstpatch/sample.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __SAMPLE_H__
 #define __SAMPLE_H__

--- a/libinstpatch/util.c
+++ b/libinstpatch/util.c
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 /**
  * SECTION: util

--- a/libinstpatch/util.h
+++ b/libinstpatch/util.h
@@ -13,9 +13,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_UTIL_H__
 #define __IPATCH_UTIL_H__

--- a/libinstpatch/version.h.in
+++ b/libinstpatch/version.h.in
@@ -15,9 +15,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #ifndef __IPATCH_VERSION_H__
 #define __IPATCH_VERSION_H__

--- a/tests/sample_list_test.c
+++ b/tests/sample_list_test.c
@@ -25,9 +25,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <libinstpatch/libinstpatch.h>
 #include <math.h>

--- a/tests/sample_test.c
+++ b/tests/sample_test.c
@@ -21,9 +21,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
- * 02110-1301, USA or on the web at http://www.gnu.org.
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 #include <libinstpatch/libinstpatch.h>
 


### PR DESCRIPTION
Update LGPL-2.1-only license notices
The FSF is now remote-only and no longer has a physical address; see
https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html#SEC4.

----

Update LGPLv2.1 license text
Based on https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt

- The FSF is now remote-only, and no longer has a physical address
- A few paragraphs are wrapped differently, without change in content